### PR TITLE
Loosen rake dependency

### DIFF
--- a/iiif_manifest.gemspec
+++ b/iiif_manifest.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bixby', '~> 1.0'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 10'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'rubocop'


### PR DESCRIPTION
CVE-2020-8130; effects developer systems only