### PR TITLE
Upgrade rake (again) to address security issue

### DIFF
--- a/iiif_manifest.gemspec
+++ b/iiif_manifest.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bixby', '~> 1.0'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'rake', '~> 10'
+  spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'rubocop'


### PR DESCRIPTION
CVE-2020-8130
moderate severity
Vulnerable versions: <= 12.3.2
Patched version: 12.3.3

There is an OS command injection vulnerability in Ruby Rake before 12.3.3 in Rake::FileList when supplying a filename that begins with the pipe character |.