### PR TITLE
Remove slash from sequence id path segment

### DIFF
--- a/lib/iiif_manifest/manifest_builder/sequence_builder.rb
+++ b/lib/iiif_manifest/manifest_builder/sequence_builder.rb
@@ -28,7 +28,7 @@ module IIIFManifest
         @sequence ||=
           begin
             sequence = sequence_factory.new
-            sequence['@id'] ||= work.manifest_url + '/sequence/normal'
+            sequence['@id'] ||= work.manifest_url + 'sequence/normal'
             sequence['rendering'] ||= populate_sequence_rendering
             canvas_builder.apply(sequence)
             sequence


### PR DESCRIPTION
The forward slash at the start of the second segment is causing our `sequence` `@id`'s to end up as just `/sequence/normal`. (The work's manifest_url is lost).

This is causing our manifests to fail validation (https://iiif.io/api/presentation/validator/service/) with "Validation Error: The identifier '/sequence/normal' is not an HTTP(S) URI"

Ex:
```
work.manifest_url + '/sequence/normal'
=> #<Pathname:/sequence/normal>

work.manifest_url + "sequence/normal"
=> #<Pathname:https://devbox.library.northwestern.edu/public/24/2a/4a/dd/-d/88/d-/46/9e/-8/8e/5-/2f/bf/a6/c2/38/12-manifest.json/sequence/normal>
```