### PR TITLE
Avoid null values in manifest for width/height/duration when not present

### DIFF
--- a/lib/iiif_manifest/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/manifest_builder/iiif_service.rb
@@ -6,7 +6,7 @@ module IIIFManifest
         @inner_hash = initial_attributes
       end
 
-      delegate :[]=, :[], :as_json, :to_json, :has_key?, to: :inner_hash
+      delegate :[]=, :[], :as_json, :to_json, :has_key?, :key?, to: :inner_hash
 
       def initial_attributes
         {}

--- a/lib/iiif_manifest/v3/manifest_builder/content_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/content_builder.rb
@@ -12,9 +12,9 @@ module IIIFManifest
 
         def apply(canvas)
           annotation['target'] = canvas['id']
-          canvas['width'] = annotation.body['width']
-          canvas['height'] = annotation.body['height']
-          canvas['duration'] = annotation.body['duration']
+          canvas['width'] = annotation.body['width'] if annotation.body['width'].present?
+          canvas['height'] = annotation.body['height'] if annotation.body['height'].present?
+          canvas['duration'] = annotation.body['duration'] if annotation.body['duration'].present?
           # Assume first item in canvas is an annotation page
           canvas.items.first.items += [annotation]
         end


### PR DESCRIPTION
Null values for width/height/duration are not valid in Presentation 3 manifests.  This PR adds tests for that and ensures that for Canvas objects.

Also included: 
- Delegate #key? to appease rubocop
