### PR TITLE
Add ID property to Annotation

### DIFF
--- a/lib/iiif_manifest/v3/manifest_builder/content_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/content_builder.rb
@@ -11,6 +11,7 @@ module IIIFManifest
         end
 
         def apply(canvas)
+          annotation['id'] = canvas['id'].to_s.gsub(/manifest.*/, "annotation/#{annotation.index}")
           annotation['target'] = canvas['id']
           canvas['width'] = annotation.body['width'] if annotation.body['width'].present?
           canvas['height'] = annotation.body['height'] if annotation.body['height'].present?

--- a/lib/iiif_manifest/v3/manifest_builder/content_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/content_builder.rb
@@ -11,12 +11,12 @@ module IIIFManifest
         end
 
         def apply(canvas)
-          annotation['id'] = canvas['id'].to_s.gsub(/manifest.*/, "annotation/#{annotation.index}")
+          # Assume first item in canvas is an annotation page
+          annotation['id'] = "#{canvas.items.first['id']}/annotation/#{annotation.index}"
           annotation['target'] = canvas['id']
           canvas['width'] = annotation.body['width'] if annotation.body['width'].present?
           canvas['height'] = annotation.body['height'] if annotation.body['height'].present?
           canvas['duration'] = annotation.body['duration'] if annotation.body['duration'].present?
-          # Assume first item in canvas is an annotation page
           canvas.items.first.items += [annotation]
         end
 

--- a/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
@@ -191,6 +191,10 @@ module IIIFManifest
             inner_hash['body']
           end
 
+          def index
+            @index ||= SecureRandom.uuid
+          end
+
           def initial_attributes
             {
               'type' => 'Annotation',

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
         expect(result['items'].first['items'].first['id']).not_to be_empty
         expect(result['items'].first['items'].first['items'].length).to eq 1
         expect(result['items'].first['items'].first['items'].first['type']).to eq 'Annotation'
+        expect(result['items'].first['items'].first['items'].first['id']).not_to be_empty
         expect(result['items'].first['items'].first['items'].first['motivation']).to eq 'painting'
         expect(result['items'].first['items'].first['items'].first['target']).to eq result['items'].first['id']
         expect(result['items'].first['items'].first['items'].first['body']['type']).to eq 'Image'
@@ -185,6 +186,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
           expect(result['items'].first['items'].first['id']).not_to be_empty
           expect(result['items'].first['items'].first['items'].length).to eq 1
           expect(result['items'].first['items'].first['items'].first['type']).to eq 'Annotation'
+          expect(result['items'].first['items'].first['items'].first['id']).not_to be_empty
           expect(result['items'].first['items'].first['items'].first['motivation']).to eq 'painting'
           expect(result['items'].first['items'].first['items'].first['target']).to eq result['items'].first['id']
           expect(result['items'].first['items'].first['items'].first['body']['type']).to eq 'Sound'


### PR DESCRIPTION
Presentation 3.0 requires all annotations to have an HTTP(S) URI, contained in an id property. This PR adds URI generation for annotations and tests to ensure that the annotation id property is populated. 