### PR TITLE
remove @ from none key

### DIFF
--- a/lib/iiif_manifest/v3/manifest_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder.rb
@@ -28,7 +28,7 @@ module IIIFManifest
 
         def obj_to_language_map(obj)
           return nil unless obj.is_a?(String) || (obj.is_a?(Array) && obj.all? { |o| o.is_a?(String) })
-          { '@none' => Array(obj) }
+          { 'none' => Array(obj) }
         end
       end
 

--- a/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::BodyBuilder do
           expect(annotation.body['height']).to eq 480
           expect(annotation.body['format']).to eq 'image/jpeg'
           expect(annotation.body['duration']).to be_nil
-          expect(annotation.body['label']).to eq('@none' => ['full'])
+          expect(annotation.body['label']).to eq('none' => ['full'])
         end
       end
 
@@ -99,7 +99,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::BodyBuilder do
           expect(annotation.body['type']).to eq 'Audio'
           expect(annotation.body['duration']).to eq 1000
           expect(annotation.body['format']).to eq 'audio/aac'
-          expect(annotation.body['label']).to eq('@none' => ['Track 1'])
+          expect(annotation.body['label']).to eq('none' => ['Track 1'])
           expect(annotation.body['width']).to be_nil
           expect(annotation.body['height']).to be_nil
         end
@@ -123,7 +123,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::BodyBuilder do
           expect(annotation.body['width']).to eq 640
           expect(annotation.body['height']).to eq 480
           expect(annotation.body['duration']).to eq 1000
-          expect(annotation.body['label']).to eq('@none' => ['Reel 1'])
+          expect(annotation.body['label']).to eq('none' => ['Reel 1'])
           expect(annotation.body['format']).to eq 'video/mp4'
         end
       end
@@ -173,7 +173,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::BodyBuilder do
           expect(annotation.body['width']).to eq 640
           expect(annotation.body['height']).to eq 480
           expect(annotation.body['duration']).to eq 1000
-          expect(annotation.body['label']).to eq('@none' => ['Reel 1'])
+          expect(annotation.body['label']).to eq('none' => ['Reel 1'])
           expect(annotation.body['format']).to eq 'video/mp4'
           expect(annotation.body['service']).to include auth_service
         end

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
   describe '#new' do
     it 'builds a canvas with a label' do
       allow(record).to receive(:to_s).and_return('Test Canvas')
-      expect(builder.canvas.label).to eq('@none' => ['Test Canvas'])
+      expect(builder.canvas.label).to eq('none' => ['Test Canvas'])
     end
   end
 

--- a/spec/lib/iiif_manifest/v3/manifest_builder/structure_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/structure_builder_spec.rb
@@ -52,14 +52,14 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::StructureBuilder do
       it 'builds the structure' do
         subject
         top_range = manifest['structures'].first
-        expect(top_range['label']).to eq('@none' => ['Table of Contents'])
+        expect(top_range['label']).to eq('none' => ['Table of Contents'])
         expect(top_range['behavior']).to eq 'top'
         expect(top_range['items'].length).to eq 2
         expect(top_range['items'][0]['type']).to eq 'Canvas'
         expect(top_range['items'][0]['id']).to eq 'http://test.host/books/book-77/manifest/canvas/Front-Cover'
         sub_range = top_range['items'][1]
         expect(sub_range['type']).to eq 'Range'
-        expect(sub_range['label']).to eq('@none' => ['Chapter 1'])
+        expect(sub_range['label']).to eq('none' => ['Chapter 1'])
         expect(sub_range['items'].length).to eq 2
         expect(sub_range['items'][0]['type']).to eq 'Canvas'
         expect(sub_range['items'][0]['id']).to eq 'http://test.host/books/book-77/manifest/canvas/Page-1'
@@ -99,7 +99,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::StructureBuilder do
       it 'builds the structure' do
         subject
         top_range = manifest['structures'].first
-        expect(top_range['label']).to eq('@none' => ['Table of Contents'])
+        expect(top_range['label']).to eq('none' => ['Table of Contents'])
         expect(top_range['behavior']).to eq 'top'
         expect(top_range['items'].length).to eq 3
         expect(top_range['items'][0]['type']).to eq 'Canvas'
@@ -119,9 +119,9 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::StructureBuilder do
     context 'with language maps' do
       let(:ranges) do
         [
-          ManifestRange.new(label: { '@none' => ['Table of Contents'] }, items: [
+          ManifestRange.new(label: { 'none' => ['Table of Contents'] }, items: [
                               double(id: 'Front-Cover'),
-                              ManifestRange.new(label: { '@none' => ['Chapter 1'] }, items: [
+                              ManifestRange.new(label: { 'none' => ['Chapter 1'] }, items: [
                                                   double(id: 'Page-1'),
                                                   double(id: 'Page-2')
                                                 ]),
@@ -152,14 +152,14 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::StructureBuilder do
       it 'builds the structure' do
         subject
         top_range = manifest['structures'].first
-        expect(top_range['label']).to eq('@none' => ['Table of Contents'])
+        expect(top_range['label']).to eq('none' => ['Table of Contents'])
         expect(top_range['behavior']).to eq 'top'
         expect(top_range['items'].length).to eq 4
         expect(top_range['items'][0]['type']).to eq 'Canvas'
         expect(top_range['items'][0]['id']).to eq 'http://test.host/books/book-77/manifest/canvas/Front-Cover'
         sub_range = top_range['items'][1]
         expect(sub_range['type']).to eq 'Range'
-        expect(sub_range['label']).to eq('@none' => ['Chapter 1'])
+        expect(sub_range['label']).to eq('none' => ['Chapter 1'])
         expect(sub_range['items'].length).to eq 2
         expect(sub_range['items'][0]['type']).to eq 'Canvas'
         expect(sub_range['items'][0]['id']).to eq 'http://test.host/books/book-77/manifest/canvas/Page-1'

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -100,11 +100,11 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
     let(:json_result) { JSON.parse(subject.to_h.to_json) }
 
     it 'has a label' do
-      expect(result.label).to eq('@none' => ['A good book'])
+      expect(result.label).to eq('none' => ['A good book'])
     end
 
     it 'has a summary' do
-      expect(result.summary).to eq('@none' => ['a brief description'])
+      expect(result.summary).to eq('none' => ['a brief description'])
     end
 
     context 'has a summary' do
@@ -157,7 +157,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
         expect(result['structures'].length).to eq 1
         structure = result['structures'].first
-        expect(structure['label']).to eq('@none' => ['Table of Contents'])
+        expect(structure['label']).to eq('none' => ['Table of Contents'])
         expect(structure['behavior']).to eq 'top'
         expect(structure['items'].length).to eq 1
         sub_range = structure['items'][0]
@@ -249,7 +249,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
         expect(result['rendering']).to eq [{
           'id' => 'http://test.host/file_set/id/download',
           'format' => 'application/pdf',
-          'label' => { '@none' => ['Download'] }
+          'label' => { 'none' => ['Download'] }
         }]
       end
     end
@@ -278,8 +278,8 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
         it 'has metadata' do
           allow(book_presenter).to receive(:manifest_metadata).and_return(metadata)
-          expect(result['metadata'][0]['label']).to eq('@none' => ['Title'])
-          expect(result['metadata'][0]['value']).to eq('@none' => ['Title of the Item'])
+          expect(result['metadata'][0]['label']).to eq('none' => ['Title'])
+          expect(result['metadata'][0]['value']).to eq('none' => ['Title of the Item'])
         end
       end
 
@@ -361,7 +361,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
       end
       it 'returns a IIIF Collection' do
         expect(result['type']).to eq 'Collection'
-        expect(result['label']).to eq('@none' => ['A good book'])
+        expect(result['label']).to eq('none' => ['A good book'])
       end
       it "doesn't build sequences" do
         expect(result['sequences']).to eq nil
@@ -374,7 +374,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
         first_child = result['manifests'].first
         expect(first_child['id']).to eq 'http://test.host/books/test2/manifest'
         expect(first_child['type']).to eq 'Manifest'
-        expect(first_child['label']).to eq('@none' => ['Inner book'])
+        expect(first_child['label']).to eq('none' => ['Inner book'])
       end
     end
 
@@ -505,7 +505,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
           expect(content_annotation_body['width']).to eq 100
           expect(content_annotation_body['format']).to eq 'video/mp4'
           expect(content_annotation_body['duration']).to eq 100
-          expect(content_annotation_body['label']).to eq('@none' => ['High'])
+          expect(content_annotation_body['label']).to eq('none' => ['High'])
         end
 
         context 'with audio file' do
@@ -523,7 +523,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
             expect(content_annotation_body.key?('width')).to eq false
             expect(content_annotation_body['format']).to eq 'audio/mp4'
             expect(content_annotation_body['duration']).to eq 100
-            expect(content_annotation_body['label']).to eq('@none' => ['High'])
+            expect(content_annotation_body['label']).to eq('none' => ['High'])
           end
         end
       end
@@ -561,7 +561,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
             expect(choice['height']).to eq 100
             expect(choice['format']).to eq 'video/mp4'
             expect(choice['duration']).to eq 100
-            expect(choice['label']['@none']).not_to be_empty
+            expect(choice['label']['none']).not_to be_empty
           end
         end
       end


### PR DESCRIPTION
According to https://iiif.io/api/presentation/3.0/#language-of-property-values, the `@none` key should be simply `none`