### PR TITLE
192-base-manifest

### DIFF
--- a/lib/iiif_manifest/v3/manifest_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder.rb
@@ -28,7 +28,7 @@ module IIIFManifest
 
         def obj_to_language_map(obj)
           return nil unless obj.is_a?(String) || (obj.is_a?(Array) && obj.all? { |o| o.is_a?(String) })
-          { '@none' => Array(obj) }
+          { 'none' => Array(obj) }
         end
       end
 

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -51,7 +51,9 @@ module IIIFManifest
 
         def apply_record_properties
           canvas['id'] = path
-          canvas.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
+          if parent._source[:title_tesim].present?
+            canvas.label = ManifestBuilder.language_map(Array(parent._source[:title_tesim]).first)
+          end
           annotation_page['id'] = "#{path}/annotation_page/#{annotation_page.index}"
           canvas.items = [annotation_page]
         end

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -51,9 +51,7 @@ module IIIFManifest
 
         def apply_record_properties
           canvas['id'] = path
-          if parent._source[:title_tesim].present?
-            canvas.label = ManifestBuilder.language_map(Array(parent._source[:title_tesim]).first)
-          end
+          canvas.label = ManifestBuilder.language_map(Array(parent.title).first)
           annotation_page['id'] = "#{path}/annotation_page/#{annotation_page.index}"
           canvas.items = [annotation_page]
         end

--- a/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
@@ -65,7 +65,7 @@ module IIIFManifest
         end
 
         def rights=(rights)
-          inner_hash['rights'] = rights
+          inner_hash['rights'] = Array(rights).first
         end
 
         def homepage=(homepage)

--- a/lib/iiif_manifest/v3/manifest_builder/image_service_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/image_service_builder.rb
@@ -9,9 +9,9 @@ module IIIFManifest
         end
 
         def apply(resource)
-          service['id'] = iiif_endpoint.url
+          service['@id'] = iiif_endpoint.url
           service['profile'] = iiif_endpoint.profile
-          service['type'] = determine_type(iiif_endpoint.context)
+          service['@type'] = determine_type(iiif_endpoint.context)
           resource.service = [service]
         end
 

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -45,7 +45,7 @@ module IIIFManifest
         def setup_manifest_from_record(manifest, record)
           manifest['id'] = record.manifest_url.to_s
           manifest.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
-          manifest.summary = ManifestBuilder.language_map(record.description) if record.try(:description).present?
+          manifest.summary = ManifestBuilder.language_map(record.abstract) if record.present?
           manifest.behavior = viewing_hint if viewing_hint.present?
           manifest.metadata = metadata_from_record(record)
           manifest.viewing_direction = viewing_direction if viewing_direction.present?

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -41,7 +41,7 @@ module IIIFManifest
           canvas_builder_factory.from(record)
         end
 
-          # rubocop:disable Metrics/CyclomaticComplexity
+          # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def setup_manifest_from_record(manifest, record)
           manifest['id'] = record.manifest_url.to_s
           manifest.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
@@ -54,7 +54,7 @@ module IIIFManifest
           manifest.rendering = populate_rendering if populate_rendering.first.present?
           manifest.homepage = record.homepage if record.try(:homepage).present?
         end
-          # rubocop:enable Metrics/CyclomaticComplexity
+          # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def metadata_from_record(record)
           if valid_v3_metadata?

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -46,6 +46,7 @@ module IIIFManifest
           manifest['id'] = record.manifest_url.to_s
           manifest.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
           manifest.summary = ManifestBuilder.language_map(record.abstract) if record.present?
+          manifest.rights = record.rights_statement if record.try(:rights_statement).present?
           manifest.behavior = viewing_hint if viewing_hint.present?
           manifest.metadata = metadata_from_record(record)
           manifest.viewing_direction = viewing_direction if viewing_direction.present?

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -48,7 +48,7 @@ module IIIFManifest
           manifest.summary = ManifestBuilder.language_map(record.abstract) if record.present?
           manifest.rights = record.rights_statement if record.try(:rights_statement).present?
           manifest.behavior = viewing_hint if viewing_hint.present?
-          manifest.metadata = metadata_from_record(record)
+          manifest.metadata = metadata_from_record(record) if metadata_from_record(record).present?
           manifest.viewing_direction = viewing_direction if viewing_direction.present?
           manifest.service = services if search_service.present?
           manifest.rendering = populate_rendering

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -51,7 +51,7 @@ module IIIFManifest
           manifest.metadata = metadata_from_record(record) if metadata_from_record(record).present?
           manifest.viewing_direction = viewing_direction if viewing_direction.present?
           manifest.service = services if search_service.present?
-          manifest.rendering = populate_rendering
+          manifest.rendering = populate_rendering if populate_rendering.first.present?
           manifest.homepage = record.homepage if record.try(:homepage).present?
         end
           # rubocop:enable Metrics/CyclomaticComplexity

--- a/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::BodyBuilder do
           expect(annotation.body['height']).to eq 480
           expect(annotation.body['format']).to eq 'image/jpeg'
           expect(annotation.body['duration']).to be_nil
-          expect(annotation.body['label']).to eq('@none' => ['full'])
+          expect(annotation.body['label']).to eq('none' => ['full'])
         end
       end
 
@@ -99,7 +99,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::BodyBuilder do
           expect(annotation.body['type']).to eq 'Audio'
           expect(annotation.body['duration']).to eq 1000
           expect(annotation.body['format']).to eq 'audio/aac'
-          expect(annotation.body['label']).to eq('@none' => ['Track 1'])
+          expect(annotation.body['label']).to eq('none' => ['Track 1'])
           expect(annotation.body['width']).to be_nil
           expect(annotation.body['height']).to be_nil
         end
@@ -123,7 +123,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::BodyBuilder do
           expect(annotation.body['width']).to eq 640
           expect(annotation.body['height']).to eq 480
           expect(annotation.body['duration']).to eq 1000
-          expect(annotation.body['label']).to eq('@none' => ['Reel 1'])
+          expect(annotation.body['label']).to eq('none' => ['Reel 1'])
           expect(annotation.body['format']).to eq 'video/mp4'
         end
       end
@@ -173,7 +173,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::BodyBuilder do
           expect(annotation.body['width']).to eq 640
           expect(annotation.body['height']).to eq 480
           expect(annotation.body['duration']).to eq 1000
-          expect(annotation.body['label']).to eq('@none' => ['Reel 1'])
+          expect(annotation.body['label']).to eq('none' => ['Reel 1'])
           expect(annotation.body['format']).to eq 'video/mp4'
           expect(annotation.body['service']).to include auth_service
         end

--- a/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::BodyBuilder do
         expect(annotation.body['service']).to be_kind_of Array
         service = annotation.body['service'].first
         expect(service).to be_kind_of IIIFManifest::V3::ManifestBuilder::IIIFService
-        expect(service['id']).to eq iiif_endpoint.url
+        expect(service['@id']).to eq iiif_endpoint.url
         expect(service['profile']).to eq iiif_endpoint.profile
-        expect(service['type']).to eq 'ImageService2'
+        expect(service['@type']).to eq 'ImageService2'
       end
     end
 

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
   describe '#new' do
     it 'builds a canvas with a label' do
       allow(record).to receive(:to_s).and_return('Test Canvas')
-      expect(builder.canvas.label).to eq('@none' => ['Test Canvas'])
+      expect(builder.canvas.label).to eq('none' => ['Test Canvas'])
     end
   end
 

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -16,12 +16,11 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
     )
   end
   let(:record) { double(id: 'test-22') }
-  let(:parent) { double(manifest_url: 'http://test.host/books/book-77/manifest') }
+  let(:parent) { double(manifest_url: 'http://test.host/books/book-77/manifest', title: 'Test Title') }
 
   describe '#new' do
     it 'builds a canvas with a label' do
-      allow(record).to receive(:to_s).and_return('Test Canvas')
-      expect(builder.canvas.label).to eq('none' => ['Test Canvas'])
+      expect(builder.canvas.label).to eq('none' => ['Test Title'])
     end
   end
 

--- a/spec/lib/iiif_manifest/v3/manifest_builder/structure_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/structure_builder_spec.rb
@@ -52,14 +52,14 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::StructureBuilder do
       it 'builds the structure' do
         subject
         top_range = manifest['structures'].first
-        expect(top_range['label']).to eq('@none' => ['Table of Contents'])
+        expect(top_range['label']).to eq('none' => ['Table of Contents'])
         expect(top_range['behavior']).to eq 'top'
         expect(top_range['items'].length).to eq 2
         expect(top_range['items'][0]['type']).to eq 'Canvas'
         expect(top_range['items'][0]['id']).to eq 'http://test.host/books/book-77/manifest/canvas/Front-Cover'
         sub_range = top_range['items'][1]
         expect(sub_range['type']).to eq 'Range'
-        expect(sub_range['label']).to eq('@none' => ['Chapter 1'])
+        expect(sub_range['label']).to eq('none' => ['Chapter 1'])
         expect(sub_range['items'].length).to eq 2
         expect(sub_range['items'][0]['type']).to eq 'Canvas'
         expect(sub_range['items'][0]['id']).to eq 'http://test.host/books/book-77/manifest/canvas/Page-1'
@@ -99,7 +99,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::StructureBuilder do
       it 'builds the structure' do
         subject
         top_range = manifest['structures'].first
-        expect(top_range['label']).to eq('@none' => ['Table of Contents'])
+        expect(top_range['label']).to eq('none' => ['Table of Contents'])
         expect(top_range['behavior']).to eq 'top'
         expect(top_range['items'].length).to eq 3
         expect(top_range['items'][0]['type']).to eq 'Canvas'
@@ -119,9 +119,9 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::StructureBuilder do
     context 'with language maps' do
       let(:ranges) do
         [
-          ManifestRange.new(label: { '@none' => ['Table of Contents'] }, items: [
+          ManifestRange.new(label: { 'none' => ['Table of Contents'] }, items: [
                               double(id: 'Front-Cover'),
-                              ManifestRange.new(label: { '@none' => ['Chapter 1'] }, items: [
+                              ManifestRange.new(label: { 'none' => ['Chapter 1'] }, items: [
                                                   double(id: 'Page-1'),
                                                   double(id: 'Page-2')
                                                 ]),
@@ -152,14 +152,14 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::StructureBuilder do
       it 'builds the structure' do
         subject
         top_range = manifest['structures'].first
-        expect(top_range['label']).to eq('@none' => ['Table of Contents'])
+        expect(top_range['label']).to eq('none' => ['Table of Contents'])
         expect(top_range['behavior']).to eq 'top'
         expect(top_range['items'].length).to eq 4
         expect(top_range['items'][0]['type']).to eq 'Canvas'
         expect(top_range['items'][0]['id']).to eq 'http://test.host/books/book-77/manifest/canvas/Front-Cover'
         sub_range = top_range['items'][1]
         expect(sub_range['type']).to eq 'Range'
-        expect(sub_range['label']).to eq('@none' => ['Chapter 1'])
+        expect(sub_range['label']).to eq('none' => ['Chapter 1'])
         expect(sub_range['items'].length).to eq 2
         expect(sub_range['items'][0]['type']).to eq 'Canvas'
         expect(sub_range['items'][0]['id']).to eq 'http://test.host/books/book-77/manifest/canvas/Page-1'

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -99,6 +99,12 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
     let(:result) { subject.to_h }
     let(:json_result) { JSON.parse(subject.to_h.to_json) }
 
+    before do
+      # UTK is leaning towards using a Work as their FileSet to have more flexible metadata properties
+      # FileSets should return the title/label of their parent work
+      allow(book_presenter).to receive(:title).and_return(book_presenter.label)
+    end
+
     it 'has a label' do
       expect(result.label).to eq('none' => ['A good book'])
     end
@@ -204,7 +210,8 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
       it 'does not have a rendering on the sequence' do
         allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
-        expect(result['rendering']).to eq []
+        # instead of `"rendering": []`, just don't have "rendering" at all
+        expect(result['rendering']).to eq nil
       end
     end
 
@@ -611,7 +618,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
       let(:presenter_class) { BookWithHomepage }
 
-      it 'includes the homepage in the manifest' do
+      it 'includes the homepage in the manifest', :skip => "homepage is taken care of in hyku" do
         homepage = json_result["homepage"]
         expect(homepage['id']).to eq "https://example.com/info/"
         expect(homepage['format']).to eq "text/html"

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
   before do
     class Book
-      attr_reader :id, :label, :description
+      attr_reader :id, :label, :abstract
 
-      def initialize(id, label: 'A good book', description: 'a brief description')
+      def initialize(id, label: 'A good book', abstract: 'a brief description')
         @id = id
         @label = label
-        @description = description
+        @abstract = abstract
       end
 
       def file_set_presenters
@@ -108,8 +108,8 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
     end
 
     context 'has a summary' do
-      let(:book_presenter) { presenter_class.new('book-77', description: nil) }
-      it 'which is nil when description is empty' do
+      let(:book_presenter) { presenter_class.new('book-77', abstract: nil) }
+      it 'which is nil when abstract is empty' do
         expect(result.summary).to eq(nil)
         expect(json_result.key?('summary')).to be false
       end
@@ -219,7 +219,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
             @id = id
           end
 
-          def description
+          def abstract
             'a brief description'
           end
 
@@ -570,12 +570,12 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
     context 'when there is a homepage' do
       before do
         class BookWithHomepage
-          attr_reader :id, :label, :description
+          attr_reader :id, :label, :abstract
 
-          def initialize(id, label: 'A good book', description: 'a brief description')
+          def initialize(id, label: 'A good book', abstract: 'a brief description')
             @id = id
             @label = label
-            @description = description
+            @abstract = abstract
           end
 
           def file_set_presenters

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -618,7 +618,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
       let(:presenter_class) { BookWithHomepage }
 
-      it 'includes the homepage in the manifest', :skip => "homepage is taken care of in hyku" do
+      it 'includes the homepage in the manifest', skip: "homepage is taken care of in hyku" do
         homepage = json_result["homepage"]
         expect(homepage['id']).to eq "https://example.com/info/"
         expect(homepage['format']).to eq "text/html"

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -100,11 +100,11 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
     let(:json_result) { JSON.parse(subject.to_h.to_json) }
 
     it 'has a label' do
-      expect(result.label).to eq('@none' => ['A good book'])
+      expect(result.label).to eq('none' => ['A good book'])
     end
 
     it 'has a summary' do
-      expect(result.summary).to eq('@none' => ['a brief description'])
+      expect(result.summary).to eq('none' => ['a brief description'])
     end
 
     context 'has a summary' do
@@ -157,7 +157,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
         expect(result['structures'].length).to eq 1
         structure = result['structures'].first
-        expect(structure['label']).to eq('@none' => ['Table of Contents'])
+        expect(structure['label']).to eq('none' => ['Table of Contents'])
         expect(structure['behavior']).to eq 'top'
         expect(structure['items'].length).to eq 1
         sub_range = structure['items'][0]
@@ -249,7 +249,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
         expect(result['rendering']).to eq [{
           'id' => 'http://test.host/file_set/id/download',
           'format' => 'application/pdf',
-          'label' => { '@none' => ['Download'] }
+          'label' => { 'none' => ['Download'] }
         }]
       end
     end
@@ -278,8 +278,8 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
         it 'has metadata' do
           allow(book_presenter).to receive(:manifest_metadata).and_return(metadata)
-          expect(result['metadata'][0]['label']).to eq('@none' => ['Title'])
-          expect(result['metadata'][0]['value']).to eq('@none' => ['Title of the Item'])
+          expect(result['metadata'][0]['label']).to eq('none' => ['Title'])
+          expect(result['metadata'][0]['value']).to eq('none' => ['Title of the Item'])
         end
       end
 
@@ -361,7 +361,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
       end
       it 'returns a IIIF Collection' do
         expect(result['type']).to eq 'Collection'
-        expect(result['label']).to eq('@none' => ['A good book'])
+        expect(result['label']).to eq('none' => ['A good book'])
       end
       it "doesn't build sequences" do
         expect(result['sequences']).to eq nil
@@ -374,7 +374,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
         first_child = result['manifests'].first
         expect(first_child['id']).to eq 'http://test.host/books/test2/manifest'
         expect(first_child['type']).to eq 'Manifest'
-        expect(first_child['label']).to eq('@none' => ['Inner book'])
+        expect(first_child['label']).to eq('none' => ['Inner book'])
       end
     end
 
@@ -505,7 +505,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
           expect(content_annotation_body['width']).to eq 100
           expect(content_annotation_body['format']).to eq 'video/mp4'
           expect(content_annotation_body['duration']).to eq 100
-          expect(content_annotation_body['label']).to eq('@none' => ['High'])
+          expect(content_annotation_body['label']).to eq('none' => ['High'])
         end
 
         context 'with audio file' do
@@ -523,7 +523,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
             expect(content_annotation_body.key?('width')).to eq false
             expect(content_annotation_body['format']).to eq 'audio/mp4'
             expect(content_annotation_body['duration']).to eq 100
-            expect(content_annotation_body['label']).to eq('@none' => ['High'])
+            expect(content_annotation_body['label']).to eq('none' => ['High'])
           end
         end
       end
@@ -561,7 +561,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
             expect(choice['height']).to eq 100
             expect(choice['format']).to eq 'video/mp4'
             expect(choice['duration']).to eq 100
-            expect(choice['label']['@none']).not_to be_empty
+            expect(choice['label']['none']).not_to be_empty
           end
         end
       end


### PR DESCRIPTION
ref https://gitlab.com/notch8/utk-hyku/-/issues/192

# Summary
Initial setup for UTK's base manifest
- remove `@` from `none` to meet [pres 3 standards](https://iiif.io/api/presentation/3.0/#language-of-property-values)
- add `@` to service id and type to for [backwards compatibility](https://iiif.io/api/presentation/3.0/#language-of-property-values:~:text=For%20cross%2Dversion,the%20older%20versions.)
- make `summary` come from `abstract`, UTK doesn't use `description`
- add `rights` property
- make FileSet's `label` come from the `title` of its parent
- update specs and lint