### PR TITLE
Add @ to service id and type for backwards compatibility

### DIFF
--- a/lib/iiif_manifest/v3/manifest_builder/image_service_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/image_service_builder.rb
@@ -9,9 +9,9 @@ module IIIFManifest
         end
 
         def apply(resource)
-          service['id'] = iiif_endpoint.url
+          service['@id'] = iiif_endpoint.url
           service['profile'] = iiif_endpoint.profile
-          service['type'] = determine_type(iiif_endpoint.context)
+          service['@type'] = determine_type(iiif_endpoint.context)
           resource.service = [service]
         end
 

--- a/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::BodyBuilder do
         expect(annotation.body['service']).to be_kind_of Array
         service = annotation.body['service'].first
         expect(service).to be_kind_of IIIFManifest::V3::ManifestBuilder::IIIFService
-        expect(service['id']).to eq iiif_endpoint.url
+        expect(service['@id']).to eq iiif_endpoint.url
         expect(service['profile']).to eq iiif_endpoint.profile
-        expect(service['type']).to eq 'ImageService2'
+        expect(service['@type']).to eq 'ImageService2'
       end
     end
 


### PR DESCRIPTION
According to pres 3 [specs](https://iiif.io/api/presentation/3.0/#:~:text=Implementations%20should%20be,Image%20API%20services.) and a conversation with Glen Robson, because `ImageService2` is an older specification, the `id` and `type` need to be `@id` and `@type`

- add `@` to service `id` and `type`
- adjust specs