### PR TITLE
add type to SearchService and AutocompleteService #initial_attributes

### DIFF
--- a/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
@@ -216,7 +216,8 @@ module IIIFManifest
             {
               '@context' => 'http://iiif.io/api/search/1/context.json',
               'profile' => 'http://iiif.io/api/search/1/search',
-              'label' => 'Search within this manifest'
+              'label' => 'Search within this manifest',
+              'type' => 'SearchService1'
             }
           end
         end

--- a/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
@@ -234,7 +234,8 @@ module IIIFManifest
           def initial_attributes
             {
               'profile' => 'http://iiif.io/api/search/1/autocomplete',
-              'label' => 'Get suggested words in this manifest'
+              'label' => 'Get suggested words in this manifest',
+              'type' => 'AutoCompleteService1'
             }
           end
         end

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -310,6 +310,8 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
         allow(book_presenter).to receive(:search_service).and_return(search_service)
         expect(result['service'][0]['profile']).to eq 'http://iiif.io/api/search/1/search'
         expect(result['service'][0]['id']).to eq 'http://test.host/books/book-77/search'
+        expect(result['service'][0]['label']).to eq 'Search within this manifest'
+        expect(result['service'][0]['type']).to eq 'SearchService1'
         expect(result['service'][0]['service']).to eq nil
       end
     end
@@ -332,6 +334,8 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
         allow(book_presenter).to receive(:autocomplete_service).and_return(autocomplete_service)
         expect(result['service'][0]['service']['id']).to eq 'http://test.host/books/book-77/autocomplete'
         expect(result['service'][0]['service']['profile']).to eq 'http://iiif.io/api/search/1/autocomplete'
+        expect(result['service'][0]['service']['label']).to eq 'Get suggested words in this manifest'
+        expect(result['service'][0]['service']['type']).to eq 'AutoCompleteService1'
       end
     end
 


### PR DESCRIPTION
According to pres 3 [specs](https://iiif.io/api/presentation/3.0/#service), there needs to be a `type` property.  Adding this property should satisfy this validation error from https://presentation-validator.iiif.io/

<img width="668" alt="image" src="https://user-images.githubusercontent.com/19597776/193398392-690eae0f-bdf9-4610-9d54-920044cf3657.png">

- add `type` property to `SearchService#initial_attributes`
