### PR TITLE
Add rights property

### DIFF
--- a/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
@@ -65,7 +65,7 @@ module IIIFManifest
         end
 
         def rights=(rights)
-          inner_hash['rights'] = rights
+          inner_hash['rights'] = Array(rights).first
         end
 
         def homepage=(homepage)

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -43,6 +43,7 @@ module IIIFManifest
           manifest['id'] = record.manifest_url.to_s
           manifest.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
           manifest.summary = ManifestBuilder.language_map(record.description) if record.try(:description).present?
+          manifest.rights = record.rights_statement if record.try(:rights_statement).present?
           manifest.behavior = viewing_hint if viewing_hint.present?
           manifest.metadata = metadata_from_record(record) if metadata_from_record(record).present?
           manifest.viewing_direction = viewing_direction if viewing_direction.present?

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -254,6 +254,28 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
       end
     end
 
+    context 'when there are no rights on the presenter' do
+      it 'does not have a rights element' do
+        allow(book_presenter).to receive(:rights_statement).and_return(nil)
+        expect(result.key?('rights')).to be false
+      end
+    end
+
+    context 'when there are a rights on the presenter' do
+      it 'does have a rights element as a String' do
+        allow(book_presenter).to receive(:rights_statement).and_return('the rights')
+        expect(result['rights'].class).to eq String
+      end
+
+      context 'when the rights on the presenter is an Array' do
+        it 'still has a rights element as a String' do
+          allow(book_presenter).to receive(:rights_statement).and_return(['the rights'])
+          expect(result['rights'].class).not_to eq Array
+          expect(result['rights'].class).to eq String
+        end
+      end
+    end
+
     context 'when there is no manifest_metadata method' do
       let(:file_presenter) { DisplayImagePresenter.new }
 


### PR DESCRIPTION
It seems the rights property was not getting set.  According to the pres 3 [specs](https://iiif.io/api/presentation/3.0/#rights), rights should be a string and not an array.

- add `rights` property to v3 manifests
- assure `rights` is a string
- disable rubocop `PerceivedComplexity`

<img width="532" alt="image" src="https://user-images.githubusercontent.com/19597776/193399585-5251f732-4c0f-4764-b020-8eefaedefecb.png">
