### PR TITLE
Adjust rendering property

### DIFF
--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -50,7 +50,7 @@ module IIIFManifest
           manifest.metadata = metadata_from_record(record)
           manifest.viewing_direction = viewing_direction if viewing_direction.present?
           manifest.service = services if search_service.present?
-          manifest.rendering = populate_rendering
+          manifest.rendering = populate_rendering if populate_rendering.first.present?
           manifest.homepage = record.homepage if record.try(:homepage).present?
         end
           # rubocop:enable Metrics/CyclomaticComplexity

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -41,7 +41,7 @@ module IIIFManifest
           canvas_builder_factory.from(record)
         end
 
-          # rubocop:disable Metrics/CyclomaticComplexity
+          # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def setup_manifest_from_record(manifest, record)
           manifest['id'] = record.manifest_url.to_s
           manifest.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
@@ -53,7 +53,7 @@ module IIIFManifest
           manifest.rendering = populate_rendering if populate_rendering.first.present?
           manifest.homepage = record.homepage if record.try(:homepage).present?
         end
-          # rubocop:enable Metrics/CyclomaticComplexity
+          # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def metadata_from_record(record)
           if valid_v3_metadata?

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -21,17 +21,14 @@ module IIIFManifest
         end
 
         def populate_rendering
-          if record.respond_to?(:sequence_rendering)
-            record.sequence_rendering.collect do |rendering|
-              sequence_rendering = rendering.to_h.except('@id', 'label')
-              sequence_rendering['id'] = rendering['@id']
-              if rendering['label'].present?
-                sequence_rendering['label'] = ManifestBuilder.language_map(rendering['label'])
-              end
-              sequence_rendering
+          return unless record.respond_to?(:sequence_rendering)
+          record.sequence_rendering.collect do |rendering|
+            sequence_rendering = rendering.to_h.except('@id', 'label')
+            sequence_rendering['id'] = rendering['@id']
+            if rendering['label'].present?
+              sequence_rendering['label'] = ManifestBuilder.language_map(rendering['label'])
             end
-          else
-            []
+            sequence_rendering
           end
         end
 
@@ -50,7 +47,7 @@ module IIIFManifest
           manifest.metadata = metadata_from_record(record)
           manifest.viewing_direction = viewing_direction if viewing_direction.present?
           manifest.service = services if search_service.present?
-          manifest.rendering = populate_rendering if populate_rendering.first.present?
+          manifest.rendering = populate_rendering if populate_rendering.present?
           manifest.homepage = record.homepage if record.try(:homepage).present?
         end
           # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
       it 'does not have a rendering on the sequence' do
         allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
-        expect(result['rendering']).to be_nil
+        expect(result.key?('rendering')).to be_false
       end
     end
 

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
       it 'does not have a rendering on the sequence' do
         allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
-        expect(result.key?('rendering')).to be_false
+        expect(result.key?('rendering')).to be false
       end
     end
 

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
       it 'does not have a rendering on the sequence' do
         allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
-        expect(result['rendering']).to eq []
+        expect(result['rendering']).to be_nil
       end
     end
 


### PR DESCRIPTION
## A proposed change

Currently if conditions are not met, `#populate_rendering` returns an empty array which makes the `rendering` appear in the manifest as such.  I propose to remove `rendering` from the manifest if it is empty so it can be cleaner.

- add guard for `manifest.rendering`
- refactor `#populate_rendering`
- disable rubocop `PerceivedComplexity`
- adjust specs