### PR TITLE
make metadata not show in the manifest if nil

### DIFF
--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -44,7 +44,7 @@ module IIIFManifest
           manifest.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
           manifest.summary = ManifestBuilder.language_map(record.description) if record.try(:description).present?
           manifest.behavior = viewing_hint if viewing_hint.present?
-          manifest.metadata = metadata_from_record(record)
+          manifest.metadata = metadata_from_record(record) if metadata_from_record(record).present?
           manifest.viewing_direction = viewing_direction if viewing_direction.present?
           manifest.service = services if search_service.present?
           manifest.rendering = populate_rendering if populate_rendering.present?

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
       it 'does not have a metadata element' do
         allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
-        expect(result['metadata']).to eq nil
+        expect(result.key?('metadata')).to be false
       end
     end
 
@@ -269,7 +269,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
         it 'has no metadata' do
           allow(book_presenter).to receive(:manifest_metadata).and_return(metadata)
-          expect(result['metadata']).to eq nil
+          expect(result.key?('metadata')).to be false
         end
       end
 
@@ -400,7 +400,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
         expect(result['type']).to eq 'Manifest'
       end
       it "doesn't build manifests" do
-        expect(result['manifests']).to eq nil
+        expect(result.key?('metadata')).to be false
       end
       it 'builds items array from all the child file sets' do
         expect(result['items'].length).to eq 2
@@ -427,7 +427,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
         expect(result['type']).to eq 'Manifest'
       end
       it "doesn't build manifests" do
-        expect(result['manifests']).to eq nil
+        expect(result.key?('metadata')).to be false
       end
       it 'builds items array from all the child file sets' do
         expect(result['items'].length).to eq 1


### PR DESCRIPTION
According to pres 3 [specs](https://iiif.io/api/presentation/3.0/#metadata),

> The value of the metadata property must be an array of JSON objects...

At the moment if there are no metadata, the `metadata` field is set to `null` which will thrown an error on the [validator](https://presentation-validator.iiif.io/).

<img width="538" alt="image" src="https://user-images.githubusercontent.com/19597776/193416272-b8827800-71c6-4066-9e76-dc98ddc31e62.png">

- add guard for metadata so it will not appear if `nil`