### PR TITLE
Add configurability to how we extract v3 manifest properties from a record

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Then you can produce the manifest on the book object like this:
 
 Provisional support for the [3.0 alpha version of the IIIF presentation api spec](https://iiif.io/api/presentation/3.0/) has been added with a focus on audiovisual content. The [change log](https://iiif.io/api/presentation/3.0/change-log/) lists the changes to the specification.
 
-The presentation 3.0 support has been contained to the `V3` namespace. Version 2.0 manifests are still be built using `IIIFManifest::ManifestFactory` while version 3.0 manifests can now be built using `IIIFManifest::V3::ManifestFactory`.
+The presentation 3.0 support has been contained to the `V3` namespace. Version 2.0 manifests are still being built using `IIIFManifest::ManifestFactory` while version 3.0 manifests can now be built using `IIIFManifest::V3::ManifestFactory`.
 
 ```ruby
   book = Book.new('book-77',[Page.new('page-99')])
@@ -160,6 +160,21 @@ The presentation 3.0 support has been contained to the `V3` namespace. Version 2
 - Range objects may now implement `#items` instead of `#ranges` and `#file_set_presenters` to allow for interleaving these objects. `#items` is not required and existing range objects should continue to work.
 - File set presenters may provide `#display_content` which should return an instance of `IIIFManifest::V3::DisplayContent` (or an array of instances in the case of a user `Choice`). `#display_image` is no longer required but will still work if provided.
 - DisplayContent may provide `#auth_service` which should return a hash containing a IIIF Authentication service definition (<https://iiif.io/api/auth/1.0/>) that will be included on the content resource.
+
+## Configuration
+
+The `label`, `rights`, `homepage`, `description` (V2 only), and `summary` (V3 only) properties can be configured to pull its information from different attributes.
+
+**NOTE:** In the V2 manifest, `label` and `description` is expected to be a string so if the model's attribute is multivalued, only the first value would be used.
+
+To enable this, add the following code to a config file at `config/initializers/iiif_manifest_config.rb` in your application.
+```ruby
+  # Example: use the default configuration but amend the summary property
+  IIIFManifest.config do |config|
+    config.manifest_property_to_record_method_name_map.merge!(summary: :abstract, rights: :license)
+  end
+```
+In the above example of a V3 manifest (since it is a `summary` instead of `description`), the `summary` property will be using the model's `#abstract` attribute value instead of the default `#description`. The `rights` property will use the model's `#license` attribute instead of the default `#rights_statement`. All other configurable properties will use their defaults.
 
 # Development
 

--- a/lib/iiif_manifest.rb
+++ b/lib/iiif_manifest.rb
@@ -17,7 +17,21 @@ module IIIFManifest
   ##
   # @api public
   #
-  # Exposes the IIIFManifest configuration
+  # Exposes the IIIFManifest configuration.
+  #
+  # In the below examples, you would add the code to a `config/initializers/iiif_manifest_config.rb` file
+  # in your application.
+  #
+  # @example
+  #   # obliterate the default configuration and only use the one we gave
+  #   IIIFManifest.config do |config|
+  #     config.manifest_property_to_record_method_name_map = { summary: :abstract }
+  #   end
+  #
+  #   # use the default configuration but amend the summary property
+  #   IIIFManifest.config do |config|
+  #     config.manifest_property_to_record_method_name_map.merge! { summary: :abstract }
+  #   end
   #
   # @yield [IIIFManifest::Configuration] if a block is passed
   # @return [IIIFManifest::Configuration]

--- a/lib/iiif_manifest.rb
+++ b/lib/iiif_manifest.rb
@@ -5,6 +5,7 @@ require 'active_support/core_ext/object'
 
 module IIIFManifest
   extend ActiveSupport::Autoload
+  autoload :Configuration
   autoload :ManifestBuilder
   autoload :ManifestFactory
   autoload :ManifestServiceLocator
@@ -12,4 +13,20 @@ module IIIFManifest
   autoload :IIIFCollection
   autoload :IIIFEndpoint
   autoload :V3
+
+  ##
+  # @api public
+  #
+  # Exposes the IIIFManifest configuration
+  #
+  # @yield [IIIFManifest::Configuration] if a block is passed
+  # @return [IIIFManifest::Configuration]
+  # @see IIIFManifest::Configuration for configuration options
+  def self.config(&block)
+    @config ||= IIIFManifest::Configuration.new
+
+    yield @config if block
+
+    @config
+  end
 end

--- a/lib/iiif_manifest.rb
+++ b/lib/iiif_manifest.rb
@@ -30,7 +30,7 @@ module IIIFManifest
   #
   #   # use the default configuration but amend the summary property
   #   IIIFManifest.config do |config|
-  #     config.manifest_property_to_record_method_name_map.merge! { summary: :abstract }
+  #     config.manifest_property_to_record_method_name_map.merge!(summary: :abstract)
   #   end
   #
   # @yield [IIIFManifest::Configuration] if a block is passed

--- a/lib/iiif_manifest/configuration.rb
+++ b/lib/iiif_manifest/configuration.rb
@@ -7,8 +7,8 @@ module IIIFManifest
   # @see IIIFManifest.config
   class Configuration
     DEFAULT_MANIFEST_PROPERTY_TO_RECORD_METHOD_NAME_MAP = {
-      summary: :description,
-      description: :description,
+      summary: :description, # for V3 manifests
+      description: :description, # for V2 manifests
       label: :to_s,
       rights: :rights_statement,
       homepage: :homepage

--- a/lib/iiif_manifest/configuration.rb
+++ b/lib/iiif_manifest/configuration.rb
@@ -6,19 +6,41 @@ module IIIFManifest
   #
   # @see IIIFManifest.config
   class Configuration
+    DEFAULT_MANIFEST_PROPERTY_TO_RECORD_METHOD_NAME_MAP = {
+      summary: :description,
+      label: :to_s,
+      rights: :rights_statement,
+      homepage: :homepage
+    }.freeze
+
+    ##
+    # @!attribute [w] manifest_property_to_record_method_name_map
+    #   @param value [Hash<Symbol, Symbol>]
+    #   @return [Hash<Symbol, Symbol>]
+    attr_writer :manifest_property_to_record_method_name_map
+    # Used to map a record's public method to a manifest property.
+    # @see manifest_value_for
+    # @see DEFAULT_MANIFEST_PROPERTY_TO_RECORD_METHOD_NAME_MAP DEFAULT_MANIFEST_PROPERTY_TO_RECORD_METHOD_NAME_MAP are the default values
+    # @return [Hash<Symbol, Symbol>]
+    def manifest_property_to_record_method_name_map
+      @manifest_property_to_record_method_name_map ||= DEFAULT_MANIFEST_PROPERTY_TO_RECORD_METHOD_NAME_MAP
+    end
+
+    ##
+    # @api private
+    # @param record [Object] has the value for the :property we want to set
+    # @param property [Symbol] IIIF manifest property
+    # @return [NilClass] the record does not have a value for the given property
+    # @return [#to_s] the record has a value that is "present"
     def manifest_value_for(record, property:)
-      method_name = map_property_to_method_name(record: record, property: property)
+      method_name = map_property_to_method_name(property: property)
       return nil unless record.respond_to?(method_name)
       record.public_send(method_name)
     end
 
-    def map_property_to_method_name(record:, property:)
-      manifest_property_to_record_method_name_map = {
-        summary: :description,
-        label: :to_s,
-        rights: :rights_statement,
-        homepage: :homepage
-      }
+    private
+
+    def map_property_to_method_name(property:)
       manifest_property_to_record_method_name_map.fetch(property)
     end
   end

--- a/lib/iiif_manifest/configuration.rb
+++ b/lib/iiif_manifest/configuration.rb
@@ -6,5 +6,20 @@ module IIIFManifest
   #
   # @see IIIFManifest.config
   class Configuration
+    def manifest_value_for(record, property:)
+      method_name = map_property_to_method_name(record: record, property: property)
+      return nil unless record.respond_to?(method_name)
+      record.public_send(method_name)
+    end
+
+    def map_property_to_method_name(record:, property:)
+      manifest_property_to_record_method_name_map = {
+        summary: :description,
+        label: :to_s,
+        rights: :rights_statement,
+        homepage: :homepage
+      }
+      manifest_property_to_record_method_name_map.fetch(property)
+    end
   end
 end

--- a/lib/iiif_manifest/configuration.rb
+++ b/lib/iiif_manifest/configuration.rb
@@ -8,6 +8,7 @@ module IIIFManifest
   class Configuration
     DEFAULT_MANIFEST_PROPERTY_TO_RECORD_METHOD_NAME_MAP = {
       summary: :description,
+      description: :description,
       label: :to_s,
       rights: :rights_statement,
       homepage: :homepage

--- a/lib/iiif_manifest/configuration.rb
+++ b/lib/iiif_manifest/configuration.rb
@@ -20,10 +20,12 @@ module IIIFManifest
     attr_writer :manifest_property_to_record_method_name_map
     # Used to map a record's public method to a manifest property.
     # @see manifest_value_for
-    # @see DEFAULT_MANIFEST_PROPERTY_TO_RECORD_METHOD_NAME_MAP DEFAULT_MANIFEST_PROPERTY_TO_RECORD_METHOD_NAME_MAP are the default values
+    # @see DEFAULT_MANIFEST_PROPERTY_TO_RECORD_METHOD_NAME_MAP DEFAULT_MANIFEST_PROPERTY_TO_RECORD_METHOD_NAME_MAP
+    #   are the default values
     # @return [Hash<Symbol, Symbol>]
     def manifest_property_to_record_method_name_map
-      @manifest_property_to_record_method_name_map ||= DEFAULT_MANIFEST_PROPERTY_TO_RECORD_METHOD_NAME_MAP
+      # the constant is frozen but we need to be able to configure something unfrozen
+      @manifest_property_to_record_method_name_map ||= DEFAULT_MANIFEST_PROPERTY_TO_RECORD_METHOD_NAME_MAP.dup
     end
 
     ##

--- a/lib/iiif_manifest/configuration.rb
+++ b/lib/iiif_manifest/configuration.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module IIIFManifest
+  ##
+  # Handles configuration for the IIIFManifest gem
+  #
+  # @see IIIFManifest.config
+  class Configuration
+  end
+end

--- a/lib/iiif_manifest/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/manifest_builder/record_property_builder.rb
@@ -10,8 +10,10 @@ module IIIFManifest
 
       def apply(manifest)
         manifest['@id'] = record.manifest_url.to_s
-        manifest.label = record.to_s
-        manifest.description = record.description
+        label = Array(::IIIFManifest.config.manifest_value_for(record, property: :label)).first
+        manifest.label = label
+        description = ::IIIFManifest.config.manifest_value_for(record, property: :description)
+        manifest.description = description
         manifest.viewing_hint = viewing_hint if viewing_hint.present?
         manifest.viewing_direction = viewing_direction if viewing_direction.present?
         manifest.metadata = record.manifest_metadata if valid_metadata?

--- a/lib/iiif_manifest/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/manifest_builder/record_property_builder.rb
@@ -12,7 +12,7 @@ module IIIFManifest
         manifest['@id'] = record.manifest_url.to_s
         label = Array(::IIIFManifest.config.manifest_value_for(record, property: :label)).first
         manifest.label = label
-        description = ::IIIFManifest.config.manifest_value_for(record, property: :description)
+        description = Array(::IIIFManifest.config.manifest_value_for(record, property: :description)).first
         manifest.description = description
         manifest.viewing_hint = viewing_hint if viewing_hint.present?
         manifest.viewing_direction = viewing_direction if viewing_direction.present?

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -41,15 +41,19 @@ module IIIFManifest
           # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def setup_manifest_from_record(manifest, record)
           manifest['id'] = record.manifest_url.to_s
-          manifest.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
-          manifest.summary = ManifestBuilder.language_map(record.description) if record.try(:description).present?
-          manifest.rights = record.rights_statement if record.try(:rights_statement).present?
+          label = ::IIIFManifest.config.manifest_value_for(record, property: :label)
+          manifest.label = ManifestBuilder.language_map(label) if label.present?
+          summary = ::IIIFManifest.config.manifest_value_for(record, property: :summary)
+          manifest.summary = ManifestBuilder.language_map(summary) if summary.present?
+          rights = ::IIIFManifest.config.manifest_value_for(record, property: :rights)
+          manifest.rights = rights if rights.present?
           manifest.behavior = viewing_hint if viewing_hint.present?
           manifest.metadata = metadata_from_record(record) if metadata_from_record(record).present?
           manifest.viewing_direction = viewing_direction if viewing_direction.present?
           manifest.service = services if search_service.present?
           manifest.rendering = populate_rendering if populate_rendering.present?
-          manifest.homepage = record.homepage if record.try(:homepage).present?
+          homepage = ::IIIFManifest.config.manifest_value_for(record, property: :homepage)
+          manifest.homepage = homepage if homepage.present?
         end
           # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 

--- a/spec/iiif_manifest_spec.rb
+++ b/spec/iiif_manifest_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 
 describe IIIFManifest do
   it 'has a version number' do
-    expect(IIIFManifest::VERSION).not_to be nil
+    expect(described_class::VERSION).not_to be nil
+  end
+  it 'is configurable' do
+    expect(described_class.config).to be_a described_class::Configuration
   end
 end

--- a/spec/lib/iiif_manifest/configuration_spec.rb
+++ b/spec/lib/iiif_manifest/configuration_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe IIIFManifest::Configuration do
+  context '#manifest_value_for' do
+    subject(:config) { described_class.new }
+
+    # rubocop:disable RSpec/VerifiedDoubles
+    let(:record) { double('record', description: 'the description', abstract: 'the abstract') }
+    # rubocop:enable RSpec/VerifiedDoubles
+    context 'with default configuration' do
+      it 'maps a record\'s description to summary' do
+        expect(config.manifest_value_for(record, property: :summary)).to eq record.description
+      end
+      it 'returns nil when the record does not have the mapped property' do
+        expect(config.manifest_value_for(record, property: :homepage)).to be_nil
+      end
+      it 'raises a KeyError when we have not configured the property' do
+        expect { config.manifest_value_for(record, property: :obviously_missing) }.to raise_error(KeyError)
+      end
+    end
+
+    context 'with configured map' do
+      before do
+        config.manifest_property_to_record_method_name_map = { summary: :abstract }
+      end
+      it 'maps according to the configuration' do
+        expect(config.manifest_value_for(record, property: :summary)).to eq record.abstract
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Prior to this commit:

The `description`, `label`, `rights`, and `homepage` properties were not configurable and relied on the methods supplied by the `#record_property_builder`.  This made it difficult if an application uses the `#abstract` instead of `#description` to populate the `summary` property.

## With this commit:
The above mentioned properties are configurable and fall back to its default when there is no configuration.

