### PR TITLE
DRAFT: modify first service id to @id, modify specs

### DIFF
--- a/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
@@ -209,7 +209,7 @@ module IIIFManifest
           end
 
           def search_service=(search_service)
-            inner_hash['id'] = search_service
+            inner_hash['@id'] = search_service
           end
 
           def initial_attributes

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -321,7 +321,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
       it 'does not have a service element' do
         allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
-        expect(result['service']).to eq nil
+        expect(result.key?('service')).to be false
       end
     end
 
@@ -331,10 +331,10 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
       it 'has a service element with the correct profile, id and without an embedded service element' do
         allow(book_presenter).to receive(:search_service).and_return(search_service)
         expect(result['service'][0]['profile']).to eq 'http://iiif.io/api/search/1/search'
-        expect(result['service'][0]['id']).to eq 'http://test.host/books/book-77/search'
+        expect(result['service'][0]['@id']).to eq 'http://test.host/books/book-77/search'
         expect(result['service'][0]['label']).to eq 'Search within this manifest'
         expect(result['service'][0]['type']).to eq 'SearchService1'
-        expect(result['service'][0]['service']).to eq nil
+        expect(result['service'][0].key?('service')).to be false
       end
     end
 
@@ -343,7 +343,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
       it 'has no service' do
         allow(book_presenter).to receive(:search_service).and_return(search_service)
-        expect(result['service']).to eq nil
+        expect(result.key?('service')).to be false
       end
     end
 
@@ -366,7 +366,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
       it 'has a service element within the first service' do
         allow(book_presenter).to receive(:search_service).and_return(search_service)
-        expect(result['service'][0]['service']).to eq nil
+        expect(result['service'][0].key?('service')).to be false
       end
     end
 
@@ -375,7 +375,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
       it 'has a service element within the first service' do
         allow(book_presenter).to receive(:autocomplete_service).and_return(autocomplete_service)
-        expect(result['service']).to eq nil
+        expect(result.key?('service')).to be false
       end
     end
 


### PR DESCRIPTION
According to the [IIIF validator](https://presentation-validator.iiif.io/), the base `service` property needs `@id` and not `id`.  Strangely enough, it didn't complain about `type` needing to be `@type` as I expected. 🤔 

<img width="558" alt="image" src="https://user-images.githubusercontent.com/19597776/193969699-12f07533-60bc-491c-8808-aea5690f092e.png">

- change `id` to `@id`
- modify specs accordingly
- change specs to instead check the existence of `service` instead of checking for that key to be `nil`