### PR TITLE
Add thumbnail property

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,26 @@ To enable this, add the following code to a config file at `config/initializers/
 ```
 In the above example of a V3 manifest (since it is a `summary` instead of `description`), the `summary` property will be using the model's `#abstract` attribute value instead of the default `#description`. The `rights` property will use the model's `#license` attribute instead of the default `#rights_statement`. All other configurable properties will use their defaults.
 
+```ruby
+  # Example: use this configuration to set the max edge length of thumbnails, default is 200
+   IIIFManifest.confg do |config|
+     config.max_edge_for_thumbnail = 100
+   end
+```
+Thumbnails have been added for version 3 manifests because [Universal Viewer](https://github.com/UniversalViewer/universalviewer/issues/102) currently require them to be explicitly set otherwise they would not show up.  The above example is used to configure what the default size for the thumbnails would be.
+
+```ruby
+# Example: use this configuration to disable thumbnails to show up by default on the manifest level (version 3 only)
+  IIIFManifest.confg do |config|
+    config.manifest_thumbnail = false
+  end
+```
+According to the Presentation API 3.0 [specifications](https://iiif.io/api/presentation/3.0/#thumbnail):
+> A Manifest *SHOULD* have the `thumbnail` property with at least one item.
+
+The above configuration allows you to disable that if desired since it is not a *MUST*.
+
+
 # Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/iiif_manifest.rb
+++ b/lib/iiif_manifest.rb
@@ -33,6 +33,12 @@ module IIIFManifest
   #     config.manifest_property_to_record_method_name_map.merge!(summary: :abstract)
   #   end
   #
+  #   # set max edge length for thumbnail images
+  #   # the below example will set the max edge to 100px
+  #   IIIFManifest.confg do |config|
+  #     config.max_edge_for_thumbnail = 100
+  #   end
+  #
   # @yield [IIIFManifest::Configuration] if a block is passed
   # @return [IIIFManifest::Configuration]
   # @see IIIFManifest::Configuration for configuration options

--- a/lib/iiif_manifest.rb
+++ b/lib/iiif_manifest.rb
@@ -39,6 +39,12 @@ module IIIFManifest
   #     config.max_edge_for_thumbnail = 100
   #   end
   #
+  #   # disable the thumbnail property on the manifest level
+  #   # since it will be shown by default
+  #   IIIFManifest.confg do |config|
+  #     config.manifest_thumbnail = false
+  #   end
+  #
   # @yield [IIIFManifest::Configuration] if a block is passed
   # @return [IIIFManifest::Configuration]
   # @see IIIFManifest::Configuration for configuration options

--- a/lib/iiif_manifest/configuration.rb
+++ b/lib/iiif_manifest/configuration.rb
@@ -30,6 +30,16 @@ module IIIFManifest
     end
 
     ##
+    # @param value [Integer]
+    attr_writer :max_edge_for_thumbnail
+    # Used to set max edge length for thumbnail generation.
+    # @return [Integer]
+    def max_edge_for_thumbnail
+      return @max_edge_for_thumbnail unless @max_edge_for_thumbnail.nil?
+      @max_edge_for_thumbnail = 200
+    end
+
+    ##
     # @api private
     # @param record [Object] has the value for the :property we want to set
     # @param property [Symbol] IIIF manifest property

--- a/lib/iiif_manifest/configuration.rb
+++ b/lib/iiif_manifest/configuration.rb
@@ -39,6 +39,14 @@ module IIIFManifest
       @max_edge_for_thumbnail = 200
     end
 
+    attr_writer :manifest_thumbnail
+    # Used to configure whether or not to show the manifest thumbnail property.
+    # @return [Boolean]
+    def manifest_thumbnail
+      return @manifest_thumbnail unless @manifest_thumbnail.nil?
+      @manifest_thumbnail = true
+    end
+
     ##
     # @api private
     # @param record [Object] has the value for the :property we want to set

--- a/lib/iiif_manifest/display_image.rb
+++ b/lib/iiif_manifest/display_image.rb
@@ -1,8 +1,9 @@
 module IIIFManifest
   class DisplayImage
-    attr_reader :url, :width, :height, :iiif_endpoint, :format
+    attr_reader :url, :type, :width, :height, :iiif_endpoint, :format
     def initialize(url, width:, height:, format: nil, iiif_endpoint: nil)
       @url = url
+      @type = 'Image'
       @width = width
       @height = height
       @format = format

--- a/lib/iiif_manifest/display_image.rb
+++ b/lib/iiif_manifest/display_image.rb
@@ -1,13 +1,14 @@
 module IIIFManifest
   class DisplayImage
-    attr_reader :url, :type, :width, :height, :iiif_endpoint, :format
-    def initialize(url, width:, height:, format: nil, iiif_endpoint: nil)
+    attr_reader :url, :type, :width, :height, :iiif_endpoint, :format, :thumbnail
+    def initialize(url, width:, height:, format: nil, iiif_endpoint: nil, thumbnail: nil)
       @url = url
       @type = 'Image'
       @width = width
       @height = height
       @format = format
       @iiif_endpoint = iiif_endpoint
+      @thumbnail = thumbnail
     end
   end
 end

--- a/lib/iiif_manifest/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/manifest_builder/iiif_service.rb
@@ -2,7 +2,6 @@ module IIIFManifest
   class ManifestBuilder
     class IIIFService
       attr_reader :inner_hash
-
       def initialize
         @inner_hash = initial_attributes
       end

--- a/lib/iiif_manifest/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/manifest_builder/iiif_service.rb
@@ -2,6 +2,7 @@ module IIIFManifest
   class ManifestBuilder
     class IIIFService
       attr_reader :inner_hash
+
       def initialize
         @inner_hash = initial_attributes
       end

--- a/lib/iiif_manifest/v3/display_content.rb
+++ b/lib/iiif_manifest/v3/display_content.rb
@@ -3,18 +3,17 @@ module IIIFManifest
     class DisplayContent
       attr_reader :url, :width, :height, :duration, :iiif_endpoint, :format, :type,
                   :label, :auth_service, :thumbnail
-      def initialize(url, type:, width: nil, height: nil, duration: nil, label: nil,
-                     format: nil, iiif_endpoint: nil, auth_service: nil, thumbnail: nil)
+      def initialize(url, type:, **kwargs)
         @url = url
         @type = type
-        @width = width
-        @height = height
-        @duration = duration
-        @label = label
-        @format = format
-        @iiif_endpoint = iiif_endpoint
-        @auth_service = auth_service
-        @thumbnail = thumbnail
+        @width = kwargs[:width]
+        @height = kwargs[:height]
+        @duration = kwargs[:duration]
+        @label = kwargs[:label]
+        @format = kwargs[:format]
+        @iiif_endpoint = kwargs[:iiif_endpoint]
+        @auth_service = kwargs[:auth_service]
+        @thumbnail = kwargs[:thumbnail]
       end
     end
   end

--- a/lib/iiif_manifest/v3/display_content.rb
+++ b/lib/iiif_manifest/v3/display_content.rb
@@ -2,9 +2,9 @@ module IIIFManifest
   module V3
     class DisplayContent
       attr_reader :url, :width, :height, :duration, :iiif_endpoint, :format, :type,
-                  :label, :auth_service
+                  :label, :auth_service, :thumbnail
       def initialize(url, type:, width: nil, height: nil, duration: nil, label: nil,
-                     format: nil, iiif_endpoint: nil, auth_service: nil)
+                     format: nil, iiif_endpoint: nil, auth_service: nil, thumbnail: nil)
         @url = url
         @type = type
         @width = width
@@ -14,6 +14,7 @@ module IIIFManifest
         @format = format
         @iiif_endpoint = iiif_endpoint
         @auth_service = auth_service
+        @thumbnail = thumbnail
       end
     end
   end

--- a/lib/iiif_manifest/v3/manifest_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder.rb
@@ -6,6 +6,7 @@ require_relative 'manifest_builder/content_builder'
 require_relative 'manifest_builder/body_builder'
 require_relative 'manifest_builder/structure_builder'
 require_relative 'manifest_builder/image_service_builder'
+require_relative 'manifest_builder/thumbnail_builder'
 
 module IIIFManifest
   module V3

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -60,7 +60,7 @@ module IIIFManifest
         end
 
         def thumbnail
-          thumbnail_builder_factory.new(display_content.first).apply(canvas)
+          thumbnail_builder_factory.new(display_content&.first).apply(canvas)
         end
 
         def annotation_page

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -56,11 +56,15 @@ module IIIFManifest
           canvas.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
           annotation_page['id'] = "#{path}/annotation_page/#{annotation_page.index}"
           canvas.items = [annotation_page]
-          canvas.thumbnail = [thumbnail] if display_content && iiif_endpoint
+          canvas.thumbnail = [thumbnail] if iiif_endpoint
         end
 
         def thumbnail
-          thumbnail_builder_factory.new(display_content&.first).apply(canvas)
+          if display_image
+            thumbnail_builder_factory.new(display_image).apply(canvas)
+          elsif display_content
+            thumbnail_builder_factory.new(display_content.first).apply(canvas)
+          end
         end
 
         def annotation_page
@@ -80,7 +84,9 @@ module IIIFManifest
         end
 
         def iiif_endpoint
-          display_content.try(:iiif_endpoint) || display_content.first.try(:iiif_endpoint)
+          display_image.try(:iiif_endpoint) ||
+            display_content.try(:iiif_endpoint) ||
+            display_content&.first.try(:iiif_endpoint)
         end
       end
     end

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -56,7 +56,7 @@ module IIIFManifest
           canvas.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
           annotation_page['id'] = "#{path}/annotation_page/#{annotation_page.index}"
           canvas.items = [annotation_page]
-          canvas.thumbnail = [thumbnail]
+          canvas.thumbnail = [thumbnail] if display_content && iiif_endpoint
         end
 
         def thumbnail
@@ -77,6 +77,10 @@ module IIIFManifest
           else
             choice_builder.new(display_content).apply(canvas)
           end
+        end
+
+        def iiif_endpoint
+          display_content.try(:iiif_endpoint) || display_content.first.try(:iiif_endpoint)
         end
       end
     end

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -3,20 +3,22 @@ module IIIFManifest
     class ManifestBuilder
       class CanvasBuilder
         attr_reader :record, :parent, :iiif_canvas_factory, :content_builder,
-                    :choice_builder, :iiif_annotation_page_factory
+                    :choice_builder, :iiif_annotation_page_factory, :iiif_thumbnail_factory
 
         def initialize(record,
                        parent,
                        iiif_canvas_factory:,
                        content_builder:,
                        choice_builder:,
-                       iiif_annotation_page_factory:)
+                       iiif_annotation_page_factory:,
+                       iiif_thumbnail_factory:)
           @record = record
           @parent = parent
           @iiif_canvas_factory = iiif_canvas_factory
           @content_builder = content_builder
           @choice_builder = choice_builder
           @iiif_annotation_page_factory = iiif_annotation_page_factory
+          @iiif_thumbnail_factory = iiif_thumbnail_factory
           apply_record_properties
           # Presentation 2.x approach
           attach_image if display_image
@@ -54,6 +56,11 @@ module IIIFManifest
           canvas.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
           annotation_page['id'] = "#{path}/annotation_page/#{annotation_page.index}"
           canvas.items = [annotation_page]
+          canvas.thumbnail = [thumbnail]
+        end
+
+        def thumbnail
+          @thumbnail ||= iiif_thumbnail_factory.new
         end
 
         def annotation_page

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -52,12 +52,29 @@ module IIIFManifest
         end
 
         def apply_record_properties
-          byebug
           canvas['id'] = path
           canvas.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
           annotation_page['id'] = "#{path}/annotation_page/#{annotation_page.index}"
           canvas.items = [annotation_page]
-          canvas.thumbnail = [thumbnail]
+          canvas.thumbnail = [build_thumbnail(record.display_image)] if record.respond_to?(:display_image)
+        end
+
+        def build_thumbnail(image)
+          thumbnail['id'] = File.join(image.iiif_endpoint.url, "full", "!200,200", "0", "default.jpg")
+          thumbnail['height'] = (image.height * reduction_ratio).round
+          thumbnail['width'] = (image.width * reduction_ratio).round
+          thumbnail['format'] = image.format
+          thumbnail
+        end
+
+        def reduction_ratio
+          width = record.display_image.width
+          height = record.display_image.height
+          max_edge = 200.0
+          return 1 if width <= max_edge && height <= max_edge
+
+          long_edge = [height, width].max
+          max_edge / long_edge
         end
 
         def thumbnail

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -62,8 +62,6 @@ module IIIFManifest
         end
 
         def apply_thumbnail_to(canvas)
-          return unless iiif_endpoint
-
           if display_image
             canvas.thumbnail = Array(thumbnail_builder_factory.new(display_image).build)
           elsif display_content.try(:first)
@@ -85,10 +83,6 @@ module IIIFManifest
           else
             choice_builder.new(display_content).apply(canvas)
           end
-        end
-
-        def iiif_endpoint
-          display_image.try(:iiif_endpoint) || Array(display_content).first.try(:iiif_endpoint)
         end
       end
     end

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -56,7 +56,7 @@ module IIIFManifest
           canvas.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
           annotation_page['id'] = "#{path}/annotation_page/#{annotation_page.index}"
           canvas.items = [annotation_page]
-          canvas.thumbnail = [build_thumbnail(record.display_image)] if record.respond_to?(:display_image)
+          canvas.thumbnail = [build_thumbnail(record.display_content)] if display_content
         end
 
         def build_thumbnail(image)
@@ -68,8 +68,8 @@ module IIIFManifest
         end
 
         def reduction_ratio
-          width = record.display_image.width
-          height = record.display_image.height
+          width = record.display_content.width
+          height = record.display_content.height
           max_edge = 200.0
           return 1 if width <= max_edge && height <= max_edge
 

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -52,6 +52,7 @@ module IIIFManifest
         end
 
         def apply_record_properties
+          byebug
           canvas['id'] = path
           canvas.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
           annotation_page['id'] = "#{path}/annotation_page/#{annotation_page.index}"

--- a/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
@@ -259,7 +259,6 @@ module IIIFManifest
 
           def initial_attributes
             {
-              'type' => 'Image'
             }
           end
         end

--- a/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
@@ -120,7 +120,7 @@ module IIIFManifest
           end
 
           def thumbnail
-            inner_hash['thumbnail'] ||= []
+            inner_hash['thumbnail']
           end
 
           def thumbnail=(thumbnail)

--- a/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
@@ -119,6 +119,14 @@ module IIIFManifest
             inner_hash['items'] = items
           end
 
+          def thumbnail
+            inner_hash['thumbnail'] ||= []
+          end
+
+          def thumbnail=(thumbnail)
+            inner_hash['thumbnail'] = thumbnail
+          end
+
           def initial_attributes
             {
               'type' => 'Canvas'
@@ -236,6 +244,14 @@ module IIIFManifest
               'profile' => 'http://iiif.io/api/search/1/autocomplete',
               'label' => 'Get suggested words in this manifest',
               'type' => 'AutoCompleteService1'
+            }
+          end
+        end
+
+        class Thumbnail < IIIFService
+          def initial_attributes
+            {
+              'type' => 'Image'
             }
           end
         end

--- a/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
@@ -72,6 +72,10 @@ module IIIFManifest
           inner_hash['homepage'] = homepage
         end
 
+        def thumbnail=(thumbnail)
+          inner_hash['thumbnail'] = thumbnail
+        end
+
         def initial_attributes
           {
             '@context' => [

--- a/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
@@ -249,6 +249,10 @@ module IIIFManifest
         end
 
         class Thumbnail < IIIFService
+          def service=(service)
+            inner_hash['service'] = service
+          end
+
           def initial_attributes
             {
               'type' => 'Image'

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -19,7 +19,7 @@ module IIIFManifest
           setup_manifest_from_record(manifest, record)
           # Build the items array
           canvas_builder.apply(manifest.items)
-          apply_thumbnail_to(manifest)
+          apply_thumbnail_to(manifest) unless manifest_thumbnail?
           manifest
         end
 
@@ -106,6 +106,10 @@ module IIIFManifest
           elsif manifest.items.first&.thumbnail.present?
             manifest.thumbnail = manifest.items.first&.thumbnail
           end
+        end
+
+        def manifest_thumbnail?
+          ::IIIFManifest.config.manifest_thumbnail == false
         end
       end
     end

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -101,10 +101,12 @@ module IIIFManifest
         end
 
         def apply_thumbnail_to(manifest)
+          return unless iiif_endpoint
+
           if display_image
-            thumbnail_builder_factory.new(display_image).apply(manifest)
+            manifest.thumbnail = Array(thumbnail_builder_factory.new(display_image).build)
           elsif display_content
-            thumbnail_builder_factory.new(display_content).apply(manifest)
+            manifest.thumbnail = Array(thumbnail_builder_factory.new(display_content).build)
           end
         end
 
@@ -116,6 +118,10 @@ module IIIFManifest
         def display_content
           return @display_content if defined?(@display_content)
           @display_content = record.try(:member_presenters)&.first&.display_content
+        end
+
+        def iiif_endpoint
+          display_image.try(:iiif_endpoint) || Array(display_content).first.try(:iiif_endpoint)
         end
       end
     end

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -101,7 +101,11 @@ module IIIFManifest
         end
 
         def apply_thumbnail_to(manifest)
-          manifest.thumbnail = manifest.items.first&.thumbnail if manifest.items.first&.thumbnail.present?
+          if manifest.is_a? IIIFManifest::Collection
+            manifest.thumbnail = manifest.items.collect(&:thumbnail).compact
+          else
+            manifest.thumbnail = manifest.items.first&.thumbnail if manifest.items.first&.thumbnail.present?
+          end
         end
       end
     end

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -103,8 +103,8 @@ module IIIFManifest
         def apply_thumbnail_to(manifest)
           if manifest.is_a? IIIFManifest::Collection
             manifest.thumbnail = manifest.items.collect(&:thumbnail).compact
-          else
-            manifest.thumbnail = manifest.items.first&.thumbnail if manifest.items.first&.thumbnail.present?
+          elsif manifest.items.first&.thumbnail.present?
+            manifest.thumbnail = manifest.items.first&.thumbnail
           end
         end
       end

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -2,15 +2,17 @@ module IIIFManifest
   module V3
     class ManifestBuilder
       class RecordPropertyBuilder < ::IIIFManifest::ManifestBuilder::RecordPropertyBuilder
-        attr_reader :canvas_builder_factory
+        attr_reader :canvas_builder_factory, :iiif_thumbnail_factory
         def initialize(record,
                        iiif_search_service_factory:,
                        iiif_autocomplete_service_factory:,
-                       canvas_builder_factory:)
+                       canvas_builder_factory:,
+                       iiif_thumbnail_factory:)
           super(record,
                 iiif_search_service_factory: iiif_search_service_factory,
                 iiif_autocomplete_service_factory: iiif_autocomplete_service_factory)
           @canvas_builder_factory = canvas_builder_factory
+          @iiif_thumbnail_factory = iiif_thumbnail_factory
         end
 
         def apply(manifest)
@@ -38,7 +40,7 @@ module IIIFManifest
           canvas_builder_factory.from(record)
         end
 
-          # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/MethodLength
         def setup_manifest_from_record(manifest, record)
           manifest['id'] = record.manifest_url.to_s
           label = ::IIIFManifest.config.manifest_value_for(record, property: :label)
@@ -54,8 +56,9 @@ module IIIFManifest
           manifest.rendering = populate_rendering if populate_rendering.present?
           homepage = ::IIIFManifest.config.manifest_value_for(record, property: :homepage)
           manifest.homepage = homepage if homepage.present?
+          manifest.thumbnail = thumbnail if thumbnail.present?
         end
-          # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/MethodLength
 
         def metadata_from_record(record)
           if valid_v3_metadata?
@@ -95,6 +98,10 @@ module IIIFManifest
           metadata_field['label'] = ManifestBuilder.language_map(field['label'])
           metadata_field['value'] = ManifestBuilder.language_map(field['value'])
           metadata_field
+        end
+
+        def thumbnail
+          @thumbnail ||= iiif_thumbnail_factory.new
         end
       end
     end

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -19,6 +19,7 @@ module IIIFManifest
           setup_manifest_from_record(manifest, record)
           # Build the items array
           canvas_builder.apply(manifest.items)
+          apply_thumbnail_to(manifest)
           manifest
         end
 
@@ -56,7 +57,6 @@ module IIIFManifest
           manifest.rendering = populate_rendering if populate_rendering.present?
           homepage = ::IIIFManifest.config.manifest_value_for(record, property: :homepage)
           manifest.homepage = homepage if homepage.present?
-          apply_thumbnail_to(manifest)
         end
         # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/MethodLength
 
@@ -101,27 +101,7 @@ module IIIFManifest
         end
 
         def apply_thumbnail_to(manifest)
-          return unless iiif_endpoint
-
-          if display_image
-            manifest.thumbnail = Array(thumbnail_builder_factory.new(display_image).build)
-          elsif display_content
-            manifest.thumbnail = Array(thumbnail_builder_factory.new(display_content).build)
-          end
-        end
-
-        def display_image
-          return @display_image if defined?(@display_image)
-          @display_image = record.try(:member_presenters)&.first&.display_image
-        end
-
-        def display_content
-          return @display_content if defined?(@display_content)
-          @display_content = record.try(:member_presenters)&.first&.display_content
-        end
-
-        def iiif_endpoint
-          display_image.try(:iiif_endpoint) || Array(display_content).first.try(:iiif_endpoint)
+          manifest.thumbnail = manifest.items.first&.thumbnail if manifest.items.first&.thumbnail.present?
         end
       end
     end

--- a/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
@@ -1,0 +1,17 @@
+module IIIFManifest
+  module V3
+    class ManifestBuilder
+      class ThumbnailBuilder
+        def initialize(display_content, iiif_thumbnail_factory:, image_service_builder_factory:)
+          @display_content = display_content
+          @iiif_thumbnail_factory = iiif_thumbnail_factory
+          @image_service_builder_factory = image_service_builder_factory
+        end
+
+        def apply(canvas)
+          
+        end
+      end
+    end
+  end
+end

--- a/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
@@ -9,10 +9,11 @@ module IIIFManifest
           @image_service_builder_factory = image_service_builder_factory
         end
 
-        def apply(canvas)
+        # @param canvas_or_manifest [#thumbnail=]
+        def apply(canvas_or_manifest)
           build_thumbnail
           image_service_builder.apply(thumbnail)
-          canvas.thumbnail = thumbnail
+          canvas_or_manifest.thumbnail = thumbnail
         end
 
         private

--- a/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
@@ -20,6 +20,7 @@ module IIIFManifest
 
         def build_thumbnail
           thumbnail['id'] = File.join(display_content.iiif_endpoint.url, 'full', '!200,200', '0', 'default.jpg')
+          thumbnail['type'] = display_content.type
           thumbnail['height'] = (display_content.height * reduction_ratio).round
           thumbnail['width'] = (display_content.width * reduction_ratio).round
           thumbnail['format'] = display_content.format

--- a/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
@@ -11,11 +11,8 @@ module IIIFManifest
 
         # @return [Array<Object>]
         def build
-          if !display_content.thumbnail.nil?
-            return Array(display_content.thumbnail.map(&:stringify_keys))
-          elsif display_content.type != "Image" || iiif_endpoint.nil?
-            return nil
-          end
+          return Array(display_content.thumbnail.map(&:stringify_keys)) unless display_content.thumbnail.nil?
+          return nil if display_content.type != "Image" || iiif_endpoint.nil?
 
           build_thumbnail
           image_service_builder.apply(thumbnail)

--- a/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
@@ -9,7 +9,6 @@ module IIIFManifest
         end
 
         def apply(canvas)
-          
         end
       end
     end

--- a/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
@@ -35,7 +35,7 @@ module IIIFManifest
         def reduction_ratio
           width = display_content.width
           height = display_content.height
-          max_edge = self.max_edge.to_f
+          max_edge = @max_edge.to_f
           return 1 if width <= max_edge && height <= max_edge
 
           long_edge = [height, width].max

--- a/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
@@ -9,11 +9,11 @@ module IIIFManifest
           @image_service_builder_factory = image_service_builder_factory
         end
 
-        # @param canvas_or_manifest [#thumbnail=]
-        def apply(canvas_or_manifest)
+        # @return [Array<Object>]
+        def build
           build_thumbnail
           image_service_builder.apply(thumbnail)
-          canvas_or_manifest.thumbnail = thumbnail
+          [thumbnail]
         end
 
         private

--- a/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
@@ -11,6 +11,12 @@ module IIIFManifest
 
         # @return [Array<Object>]
         def build
+          if !display_content.thumbnail.nil?
+            return Array(display_content.thumbnail.map(&:stringify_keys))
+          elsif display_content.type != "Image" || iiif_endpoint.nil?
+            return nil
+          end
+
           build_thumbnail
           image_service_builder.apply(thumbnail)
           [thumbnail]

--- a/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
@@ -19,7 +19,13 @@ module IIIFManifest
         private
 
         def build_thumbnail
-          thumbnail['id'] = File.join(display_content.iiif_endpoint.url, 'full', '!200,200', '0', 'default.jpg')
+          thumbnail['id'] = File.join(
+            display_content.iiif_endpoint.url,
+            'full',
+            "!#{max_edge},#{max_edge}",
+            '0',
+            'default.jpg'
+          )
           thumbnail['type'] = display_content.type
           thumbnail['height'] = (display_content.height * reduction_ratio).round
           thumbnail['width'] = (display_content.width * reduction_ratio).round
@@ -29,11 +35,15 @@ module IIIFManifest
         def reduction_ratio
           width = display_content.width
           height = display_content.height
-          max_edge = 200.0
+          max_edge = self.max_edge.to_f
           return 1 if width <= max_edge && height <= max_edge
 
           long_edge = [height, width].max
           max_edge / long_edge
+        end
+
+        def max_edge
+          @max_edge = ::IIIFManifest.config.max_edge_for_thumbnail
         end
 
         def thumbnail

--- a/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
@@ -2,6 +2,7 @@ module IIIFManifest
   module V3
     class ManifestBuilder
       class ThumbnailBuilder
+        attr_reader :display_content, :iiif_thumbnail_factory, :image_service_builder_factory
         def initialize(display_content, iiif_thumbnail_factory:, image_service_builder_factory:)
           @display_content = display_content
           @iiif_thumbnail_factory = iiif_thumbnail_factory
@@ -9,6 +10,32 @@ module IIIFManifest
         end
 
         def apply(canvas)
+          build_thumbnail
+          # image_service_builder
+          canvas.thumbnail = thumbnail
+        end
+
+        private
+
+        def build_thumbnail
+          thumbnail['id'] = File.join(display_content.iiif_endpoint.url, 'full', '!200,200', '0', 'default.jpg')
+          thumbnail['height'] = (display_content.height * reduction_ratio).round
+          thumbnail['width'] = (display_content.width * reduction_ratio).round
+          thumbnail['format'] = display_content.format
+        end
+
+        def reduction_ratio
+          width = display_content.width
+          height = display_content.height
+          max_edge = 200.0
+          return 1 if width <= max_edge && height <= max_edge
+
+          long_edge = [height, width].max
+          max_edge / long_edge
+        end
+
+        def thumbnail
+          @thumbnail ||= iiif_thumbnail_factory.new
         end
       end
     end

--- a/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder.rb
@@ -11,7 +11,7 @@ module IIIFManifest
 
         def apply(canvas)
           build_thumbnail
-          # image_service_builder
+          image_service_builder.apply(thumbnail)
           canvas.thumbnail = thumbnail
         end
 
@@ -36,6 +36,14 @@ module IIIFManifest
 
         def thumbnail
           @thumbnail ||= iiif_thumbnail_factory.new
+        end
+
+        def iiif_endpoint
+          display_content.try(:iiif_endpoint)
+        end
+
+        def image_service_builder
+          image_service_builder_factory.new(iiif_endpoint)
         end
       end
     end

--- a/lib/iiif_manifest/v3/manifest_service_locator.rb
+++ b/lib/iiif_manifest/v3/manifest_service_locator.rb
@@ -30,7 +30,7 @@ module IIIFManifest
             iiif_search_service_factory: iiif_search_service_factory,
             iiif_autocomplete_service_factory: iiif_autocomplete_service_factory,
             canvas_builder_factory: deep_canvas_builder_factory,
-            iiif_thumbnail_factory: iiif_thumbnail_factory
+            thumbnail_builder_factory: thumbnail_builder_factory
             # canvas_builder_factory: canvas_builder_factory
           )
         end

--- a/lib/iiif_manifest/v3/manifest_service_locator.rb
+++ b/lib/iiif_manifest/v3/manifest_service_locator.rb
@@ -29,7 +29,8 @@ module IIIFManifest
             ManifestBuilder::RecordPropertyBuilder,
             iiif_search_service_factory: iiif_search_service_factory,
             iiif_autocomplete_service_factory: iiif_autocomplete_service_factory,
-            canvas_builder_factory: deep_canvas_builder_factory
+            canvas_builder_factory: deep_canvas_builder_factory,
+            iiif_thumbnail_factory: iiif_thumbnail_factory
             # canvas_builder_factory: canvas_builder_factory
           )
         end

--- a/lib/iiif_manifest/v3/manifest_service_locator.rb
+++ b/lib/iiif_manifest/v3/manifest_service_locator.rb
@@ -56,7 +56,7 @@ module IIIFManifest
             content_builder: content_builder,
             choice_builder: choice_builder,
             iiif_annotation_page_factory: iiif_annotation_page_factory,
-            iiif_thumbnail_factory: iiif_thumbnail_factory
+            thumbnail_builder_factory: thumbnail_builder_factory
           )
         end
 
@@ -81,6 +81,14 @@ module IIIFManifest
           IIIFManifest::ManifestServiceLocator::InjectedFactory.new(
             ManifestBuilder::BodyBuilder,
             iiif_body_factory: iiif_body_factory,
+            image_service_builder_factory: image_service_builder_factory
+          )
+        end
+
+        def thumbnail_builder_factory
+          IIIFManifest::ManifestServiceLocator::InjectedFactory.new(
+            ManifestBuilder::ThumbnailBuilder,
+            iiif_thumbnail_factory: iiif_thumbnail_factory,
             image_service_builder_factory: image_service_builder_factory
           )
         end

--- a/lib/iiif_manifest/v3/manifest_service_locator.rb
+++ b/lib/iiif_manifest/v3/manifest_service_locator.rb
@@ -55,7 +55,8 @@ module IIIFManifest
             iiif_canvas_factory: iiif_canvas_factory,
             content_builder: content_builder,
             choice_builder: choice_builder,
-            iiif_annotation_page_factory: iiif_annotation_page_factory
+            iiif_annotation_page_factory: iiif_annotation_page_factory,
+            iiif_thumbnail_factory: iiif_thumbnail_factory
           )
         end
 
@@ -141,6 +142,10 @@ module IIIFManifest
 
         def iiif_autocomplete_service_factory
           IIIFManifest::V3::ManifestBuilder::IIIFManifest::AutocompleteService
+        end
+
+        def iiif_thumbnail_factory
+          IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail
         end
       end
     end

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
 
   let(:iiif_thumbnail) do
     thumbnail = IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail.new
+    thumbnail['type'] = 'Image'
     thumbnail['width'] = 200
     thumbnail['height'] = 150
     thumbnail['duration'] = nil

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -182,7 +182,6 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
     end
   end
 
-
   describe '#new' do
     it 'builds a canvas with a label' do
       allow(record).to receive(:to_s).and_return('Test Canvas')
@@ -213,5 +212,4 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
       end
     end
   end
-
 end

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
       content_builder: content_builder,
       choice_builder: IIIFManifest::V3::ManifestBuilder::ChoiceBuilder,
       iiif_annotation_page_factory: IIIFManifest::V3::ManifestBuilder::IIIFManifest::AnnotationPage,
-      iiif_thumbnail_factory: IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail
+      thumbnail_builder_factory: thumbnail_builder_factory
     )
   end
   let(:record) { double(id: 'test-22') }
@@ -122,6 +122,8 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
         allow(body_builder_factory).to receive(:new).and_return(body_builder)
         allow(iiif_annotation_factory).to receive(:new).and_return(iiif_annotation)
         allow(content_builder).to receive(:new).and_return(built_content)
+        allow(thumbnail_builder).to receive(:apply).and_return(iiif_thumbnail)
+        allow(thumbnail_builder_factory).to receive(:new).and_return(thumbnail_builder)
       end
 
       let(:iiif_body) do
@@ -130,6 +132,14 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
         body['height'] = '100px'
         body['duration'] = nil
         body
+      end
+
+      let(:iiif_thumbnail) do
+        thumbnail = IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail.new
+        thumbnail['width'] = 200
+        thumbnail['height'] = 150
+        thumbnail['duration'] = nil
+        thumbnail
       end
 
       let(:iiif_annotation) do
@@ -147,6 +157,14 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
       end
 
       let(:body_builder_factory) do
+        double
+      end
+
+      let(:thumbnail_builder) do
+        instance_double(IIIFManifest::V3::ManifestBuilder::ThumbnailBuilder)
+      end
+
+      let(:thumbnail_builder_factory) do
         double
       end
 
@@ -176,8 +194,6 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
         expect(thumbnail).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail
         thumbnail_values = thumbnail.inner_hash
         expect(thumbnail_values).to include "type" => "Image"
-        expect(thumbnail_values).to include "id"
-        expect(thumbnail_values).to include "id" => "http://example.com/img1/full/!200,200/0/default.jpg"
         expect(thumbnail_values).to include "width" => 200
         expect(thumbnail_values).to include "height" => 150
 

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -90,14 +90,16 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
     end
 
     context 'when the display content is populated for a record' do
-      let(:url) { 'http://example.com/img1' }
+      let(:url) { 'http://example.com/img1/full/600,/0/default.jpg' }
+      let(:iiif_endpoint) { double('endpoint', url: 'http://example.com/img1') }
       let(:display_content) do
         IIIFManifest::V3::DisplayContent.new(url,
                                              width: 640,
                                              height: 480,
                                              type: 'Image',
                                              format: 'image/jpeg',
-                                             label: 'full')
+                                             label: 'full',
+                                             iiif_endpoint: iiif_endpoint)
       end
       let(:record) do
         MyWork.new(display_content: display_content)
@@ -167,6 +169,17 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
 
         expect(values).to include "type" => "Canvas"
         expect(values).to include "id" => "http://test.host/books/book-77/manifest/canvas/test-22"
+        expect(values).to include "items"
+
+        expect(values).to include "thumbnail"
+        thumbnail = values['thumbnail'].first
+        expect(thumbnail).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail
+        thumbnail_values = thumbnail.inner_hash
+        expect(thumbnail_values).to include "type" => "Image"
+        expect(thumbnail_values).to include "id"
+        expect(thumbnail_values).to include "id" => "http://example.com/img1/full/!200,200/0/default.jpg"
+        expect(thumbnail_values).to include "width" => 200
+        expect(thumbnail_values).to include "height" => 150
 
         items = values['items']
         expect(items.length).to eq 1

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
     allow(body_builder_factory).to receive(:new).and_return(body_builder)
     allow(iiif_annotation_factory).to receive(:new).and_return(iiif_annotation)
     allow(content_builder).to receive(:new).and_return(built_content)
-    allow(thumbnail_builder).to receive(:apply).and_return(iiif_thumbnail)
+    allow(thumbnail_builder).to receive(:build).and_return(iiif_thumbnail)
     allow(thumbnail_builder_factory).to receive(:new).and_return(thumbnail_builder)
   end
 
@@ -82,7 +82,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
   end
 
   let(:iiif_annotation_factory) do
-    double
+    double('IIIF Annotation Factory')
   end
 
   let(:body_builder) do
@@ -90,7 +90,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
   end
 
   let(:body_builder_factory) do
-    double
+    double('Body Builder')
   end
 
   let(:thumbnail_builder) do
@@ -98,7 +98,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
   end
 
   let(:thumbnail_builder_factory) do
-    double
+    double('Thumbnail Builder')
   end
 
   let(:built_content) do
@@ -110,7 +110,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
   end
 
   let(:content_builder) do
-    double
+    double('Content Builder')
   end
 
   describe '#canvas' do

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
     end
 
     context 'when the display content is populated for a record' do
-      let(:url) { 'http://example.com/img1/full/600,/0/default.jpg' }
+      let(:url) { 'http://example.com/img1' }
       let(:display_content) do
         IIIFManifest::V3::DisplayContent.new(url,
                                              width: 640,
@@ -167,15 +167,6 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
 
         expect(values).to include "type" => "Canvas"
         expect(values).to include "id" => "http://test.host/books/book-77/manifest/canvas/test-22"
-
-        expect(values).to include 'items'
-        thumbnail = values['thumbnail'].first
-        expect(thumbnail).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail
-        thumbnail_values = thumbnail.inner_hash
-        expect(thumbnail_values).to include "type" => "Image"
-        # binding.pry
-        expect(thumbnail_values).to include "id"
-        # expect(thumbnail_values).to include "id" => 'http://example.com/img1/full/!200,200/0/default.jpg'
 
         items = values['items']
         expect(items.length).to eq 1

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -173,6 +173,9 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
         expect(thumbnail).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail
         thumbnail_values = thumbnail.inner_hash
         expect(thumbnail_values).to include "type" => "Image"
+        # binding.pry
+        expect(thumbnail_values).to include "id"
+        # expect(thumbnail_values).to include "id" => 'http://example.com/img1/full/!200,200/0/default.jpg'
 
         items = values['items']
         expect(items.length).to eq 1

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
       iiif_canvas_factory: IIIFManifest::V3::ManifestBuilder::IIIFManifest::Canvas,
       content_builder: content_builder,
       choice_builder: IIIFManifest::V3::ManifestBuilder::ChoiceBuilder,
-      iiif_annotation_page_factory: IIIFManifest::V3::ManifestBuilder::IIIFManifest::AnnotationPage
+      iiif_annotation_page_factory: IIIFManifest::V3::ManifestBuilder::IIIFManifest::AnnotationPage,
+      iiif_thumbnail_factory: IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail
     )
   end
   let(:record) { double(id: 'test-22') }
@@ -89,7 +90,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
     end
 
     context 'when the display content is populated for a record' do
-      let(:url) { 'http://example.com/img1' }
+      let(:url) { 'http://example.com/img1/full/600,/0/default.jpg' }
       let(:display_content) do
         IIIFManifest::V3::DisplayContent.new(url,
                                              width: 640,
@@ -168,6 +169,11 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
         expect(values).to include "id" => "http://test.host/books/book-77/manifest/canvas/test-22"
 
         expect(values).to include 'items'
+        thumbnail = values['thumbnail'].first
+        expect(thumbnail).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail
+        thumbnail_values = thumbnail.inner_hash
+        expect(thumbnail_values).to include "type" => "Image"
+
         items = values['items']
         expect(items.length).to eq 1
         page = items.first

--- a/spec/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder_spec.rb
@@ -23,12 +23,13 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::ThumbnailBuilder do
       width: 640,
       height: 480,
       iiif_endpoint: iiif_endpoint,
-      format: 'Image'
+      format: 'image/jpeg'
     )
   end
   let(:canvas) { IIIFManifest::V3::ManifestBuilder::IIIFManifest::Canvas.new }
   let(:image_service_builder_factory) { IIIFManifest::V3::ManifestServiceLocator.image_service_builder_factory }
   let(:thumbnail) { thumbnail_builder.first }
+
   before do
     thumbnail_builder
   end
@@ -45,7 +46,6 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::ThumbnailBuilder do
       expect(thumbnail['id']).to eq url + '/full/!200,200/0/default.jpg'
       expect(thumbnail['width']).to eq 200
       expect(thumbnail['height']).to eq 150
-
       expect(thumbnail['service']).to be_an Array
       service = thumbnail['service'].first
       expect(service).to be_kind_of IIIFManifest::V3::ManifestBuilder::IIIFService

--- a/spec/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder_spec.rb
@@ -9,19 +9,61 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::ThumbnailBuilder do
       image_service_builder_factory: image_service_builder_factory
     )
   end
-  let(:url) { 'http://example.com/img1/full/600,/0/default.jpg' }
-  let(:display_content) { IIIFManifest::DisplayImage.new(url, width: 640, height: 480) }
+  let(:url) { 'http://example.com/img1' }
+  let(:iiif_endpoint) { double }
+  let(:display_content) do
+    IIIFManifest::DisplayImage.new(
+      url,
+      width: 640,
+      height: 480,
+      iiif_endpoint: iiif_endpoint,
+      format: 'Image'
+    )
+  end
   let(:canvas) { IIIFManifest::V3::ManifestBuilder::IIIFManifest::Canvas.new }
   let(:image_service_builder_factory) { IIIFManifest::V3::ManifestServiceLocator.image_service_builder_factory }
 
-  describe '#apply' do
-    subject(:thumbnail_builder) { builder.apply(canvas) }
+  before do
+    allow(iiif_endpoint).to receive(:url).and_return(url)
+    builder.apply(canvas)
+  end
 
-    context 'without iiif_endpoint' do
-      it 'sets a thumbnail on the canvas' do
-        thumbnail_builder
-        expect(canvas.thumbnail).to be_kind_of IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail
+  describe '#apply' do
+    it 'sets a thumbnail on the canvas' do
+      expect(canvas.thumbnail).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail
+    end
+  end
+
+  describe '#build_thumbnail' do
+    it 'sets properties on the thumbnail' do
+      expect(canvas.thumbnail['type']).to eq 'Image'
+      expect(canvas.thumbnail['id']).to eq url + '/full/!200,200/0/default.jpg'
+      expect(canvas.thumbnail['width']).to eq 200
+      expect(canvas.thumbnail['height']).to eq 150
+    end
+  end
+
+  describe '#reduction_ratio' do
+    context 'when the content is wider' do
+      it 'creates a multiplier based off the max width of 200' do
+        allow(display_content).to receive(:width).and_return(2000)
+        allow(display_content).to receive(:height).and_return(1000)
+        expect(builder.send(:reduction_ratio)).to eq 0.1
       end
+    end
+
+    context 'when the content is taller' do
+      it 'creates a multiplier based off the max height of 200' do
+        allow(display_content).to receive(:width).and_return(1000)
+        allow(display_content).to receive(:height).and_return(2000)
+        expect(builder.send(:reduction_ratio)).to eq 0.1
+      end
+    end
+  end
+
+  describe '#thumbnail' do
+    it 'creates a new thumbnail' do
+      expect(builder.send(:thumbnail)).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail
     end
   end
 end

--- a/spec/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 RSpec.describe IIIFManifest::V3::ManifestBuilder::ThumbnailBuilder do
-  subject(:thumbnail_builder) { builder.apply(canvas) }
+  subject(:thumbnail_builder) { builder.build }
   let(:builder) do
     described_class.new(
       display_content,
@@ -28,26 +28,26 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::ThumbnailBuilder do
   end
   let(:canvas) { IIIFManifest::V3::ManifestBuilder::IIIFManifest::Canvas.new }
   let(:image_service_builder_factory) { IIIFManifest::V3::ManifestServiceLocator.image_service_builder_factory }
-
+  let(:thumbnail) { thumbnail_builder.first }
   before do
     thumbnail_builder
   end
 
-  describe '#apply' do
+  describe '#build' do
     it 'sets a thumbnail on the canvas' do
-      expect(canvas.thumbnail).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail
+      expect(thumbnail).to be_kind_of IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail
     end
   end
 
   describe '#build_thumbnail' do
     it 'sets properties on the thumbnail' do
-      expect(canvas.thumbnail['type']).to eq 'Image'
-      expect(canvas.thumbnail['id']).to eq url + '/full/!200,200/0/default.jpg'
-      expect(canvas.thumbnail['width']).to eq 200
-      expect(canvas.thumbnail['height']).to eq 150
+      expect(thumbnail['type']).to eq 'Image'
+      expect(thumbnail['id']).to eq url + '/full/!200,200/0/default.jpg'
+      expect(thumbnail['width']).to eq 200
+      expect(thumbnail['height']).to eq 150
 
-      expect(canvas.thumbnail['service']).to be_an Array
-      service = canvas.thumbnail['service'].first
+      expect(thumbnail['service']).to be_an Array
+      service = thumbnail['service'].first
       expect(service).to be_kind_of IIIFManifest::V3::ManifestBuilder::IIIFService
       expect(service['@id']).to eq iiif_endpoint.url
       expect(service['profile']).to eq iiif_endpoint.profile

--- a/spec/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/thumbnail_builder_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe IIIFManifest::V3::ManifestBuilder::ThumbnailBuilder do
+  let(:builder) do
+    described_class.new(
+      display_content,
+      iiif_thumbnail_factory: IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail,
+      image_service_builder_factory: image_service_builder_factory
+    )
+  end
+  let(:url) { 'http://example.com/img1/full/600,/0/default.jpg' }
+  let(:display_content) { IIIFManifest::DisplayImage.new(url, width: 640, height: 480) }
+  let(:canvas) { IIIFManifest::V3::ManifestBuilder::IIIFManifest::Canvas.new }
+  let(:image_service_builder_factory) { IIIFManifest::V3::ManifestServiceLocator.image_service_builder_factory }
+
+  describe '#apply' do
+    subject(:thumbnail_builder) { builder.apply(canvas) }
+
+    context 'without iiif_endpoint' do
+      it 'sets a thumbnail on the canvas' do
+        thumbnail_builder
+        expect(canvas.thumbnail).to be_kind_of IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail
+      end
+    end
+  end
+end

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -564,24 +564,26 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
             expect(content_annotation_body['duration']).to eq 100
             expect(content_annotation_body['label']).to eq('none' => ['High'])
           end
+        end
 
-	  context 'with thumbnail provided' do
-	    let(:content) do
-	      IIIFManifest::V3::DisplayContent.new(SecureRandom.uuid, duration: 100,
-								      type: 'Sound',
-								      format: 'audio/mp4',
-								      label: 'High',
-								      thumbnail: [{ id: "test.host/thumbnails/thumb.mp4", format: "audio/mp4" }])
-	    end
-	    it 'sets thumbnail on manifest and canvas' do
-	      manifest_thumbnail = result['thumbnail'].first
-	      expect(manifest_thumbnail['id']).to eq 'test.host/thumbnails/thumb.mp4'
-	      expect(manifest_thumbnail['format']).to eq 'audio/mp4'
-              canvas_thumbnail = result.items.first['thumbnail'].first
-	      expect(canvas_thumbnail['id']).to eq 'test.host/thumbnails/thumb.mp4'
-	      expect(canvas_thumbnail['format']).to eq 'audio/mp4'
-	    end
-	  end
+        context 'with thumbnail provided' do
+          let(:content) do
+            IIIFManifest::V3::DisplayContent.new(SecureRandom.uuid,
+                   duration: 100,
+                   type: 'Sound',
+                   format: 'audio/mp4',
+                   label: 'High',
+                   thumbnail: [{ id: "test.host/thumbnails/thumb.mp4",
+                                 format: "audio/mp4" }])
+          end
+          it 'uses provided thumbnail on manifest and canvas' do
+            manifest_thumbnail = result['thumbnail'].first
+            expect(manifest_thumbnail['id']).to eq 'test.host/thumbnails/thumb.mp4'
+            expect(manifest_thumbnail['format']).to eq 'audio/mp4'
+            canvas_thumbnail = result.items.first['thumbnail'].first
+            expect(canvas_thumbnail['id']).to eq 'test.host/thumbnails/thumb.mp4'
+            expect(canvas_thumbnail['format']).to eq 'audio/mp4'
+          end
         end
       end
 

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -157,8 +157,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
       end
 
       it 'has a thumbnail property' do
-        allow(book_presenter).to receive(:member_presenters).and_return([file_presenter])
-
+        allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
         thumbnail = result['thumbnail'].first
         expect(thumbnail['id']).to eq 'test.host/images/image-77/full/!200,200/0/default.jpg'
         expect(thumbnail['height']).to eq 150

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -67,7 +67,13 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
       end
 
       def display_image
-        IIIFManifest::DisplayImage.new(id, width: 100, height: 100, format: 'image/jpeg')
+        IIIFManifest::DisplayImage.new(
+          'test.host/images/image-77/full/600,/0/default.jpg',
+          width: 2000,
+          height: 1500,
+          format: 'image/jpeg',
+          iiif_endpoint: IIIFManifest::IIIFEndpoint.new('test.host/images/image-77')
+        )
       end
     end
 
@@ -136,8 +142,8 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
         expect(result['items'].length).to eq 1
         expect(result['items'].first['type']).to eq 'Canvas'
         expect(result['items'].first['id']).to eq 'http://test.host/books/book-77/manifest/canvas/test-22'
-        expect(result['items'].first['height']).to eq 100
-        expect(result['items'].first['width']).to eq 100
+        expect(result['items'].first['height']).to eq 1500
+        expect(result['items'].first['width']).to eq 2000
         expect(result['items'].first['items'].first['type']).to eq 'AnnotationPage'
         expect(result['items'].first['items'].first['id']).not_to be_empty
         expect(result['items'].first['items'].first['items'].length).to eq 1
@@ -147,10 +153,24 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
         expect(result['items'].first['items'].first['items'].first['target']).to eq result['items'].first['id']
         expect(result['items'].first['items'].first['items'].first['body']['type']).to eq 'Image'
         expect(result['items'].first['items'].first['items'].first['body']['id']).not_to be_empty
-        expect(result['items'].first['items'].first['items'].first['body']['height']).to eq 100
-        expect(result['items'].first['items'].first['items'].first['body']['width']).to eq 100
+        expect(result['items'].first['items'].first['items'].first['body']['height']).to eq 1500
+        expect(result['items'].first['items'].first['items'].first['body']['width']).to eq 2000
         expect(result['items'].first['items'].first['items'].first['body']['format']).to eq 'image/jpeg'
       end
+
+      it 'has a thumbnail property' do
+        allow(book_presenter).to receive(:member_presenters).and_return([file_presenter])
+
+        result
+
+        thumbnail = result['thumbnail'].inner_hash
+        expect(thumbnail['id']).to eq 'test.host/images/image-77/full/!200,200/0/default.jpg'
+        expect(thumbnail['height']).to eq 150
+        expect(thumbnail['width']).to eq 200
+        expect(thumbnail['format']).to eq 'image/jpeg'
+        expect(thumbnail['service'].first).to be_kind_of IIIFManifest::V3::ManifestBuilder::IIIFService
+      end
+
       it 'builds a structure if it can' do
         allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
         allow(book_presenter.ranges[0].ranges[0]).to receive(:file_set_presenters).and_return([file_presenter])

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -564,6 +564,24 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
             expect(content_annotation_body['duration']).to eq 100
             expect(content_annotation_body['label']).to eq('none' => ['High'])
           end
+
+	  context 'with thumbnail provided' do
+	    let(:content) do
+	      IIIFManifest::V3::DisplayContent.new(SecureRandom.uuid, duration: 100,
+								      type: 'Sound',
+								      format: 'audio/mp4',
+								      label: 'High',
+								      thumbnail: [{ id: "test.host/thumbnails/thumb.mp4", format: "audio/mp4" }])
+	    end
+	    it 'sets thumbnail on manifest and canvas' do
+	      manifest_thumbnail = result['thumbnail'].first
+	      expect(manifest_thumbnail['id']).to eq 'test.host/thumbnails/thumb.mp4'
+	      expect(manifest_thumbnail['format']).to eq 'audio/mp4'
+              canvas_thumbnail = result.items.first['thumbnail'].first
+	      expect(canvas_thumbnail['id']).to eq 'test.host/thumbnails/thumb.mp4'
+	      expect(canvas_thumbnail['format']).to eq 'audio/mp4'
+	    end
+	  end
         end
       end
 

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -584,6 +584,20 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
             expect(canvas_thumbnail['id']).to eq 'test.host/thumbnails/thumb.mp4'
             expect(canvas_thumbnail['format']).to eq 'audio/mp4'
           end
+
+          # rubocop:disable RSpec/NestedGroups
+          context 'when manifest thumbnail is disabled' do
+            let(:config) { instance_double(IIIFManifest::Configuration) }
+            it 'does not have a thumbnail property on the manifest' do
+              allow(IIIFManifest).to receive(:config).and_return config
+              allow(config).to receive(:manifest_thumbnail).and_return false
+              # adding this line to get past Rpsec unexpected message error
+              allow(config).to receive(:manifest_value_for).and_return 'A good book'
+
+              expect(result.key?('thumbnail')).to be false
+            end
+          end
+          # rubocop:enable RSpec/NestedGroups
         end
       end
 

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -137,8 +137,6 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
       it 'returns items' do
         allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
 
-        result
-
         expect(result['items'].length).to eq 1
         expect(result['items'].first['type']).to eq 'Canvas'
         expect(result['items'].first['id']).to eq 'http://test.host/books/book-77/manifest/canvas/test-22'
@@ -161,9 +159,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
       it 'has a thumbnail property' do
         allow(book_presenter).to receive(:member_presenters).and_return([file_presenter])
 
-        result
-
-        thumbnail = result['thumbnail'].inner_hash
+        thumbnail = result['thumbnail'].first
         expect(thumbnail['id']).to eq 'test.host/images/image-77/full/!200,200/0/default.jpg'
         expect(thumbnail['height']).to eq 150
         expect(thumbnail['width']).to eq 200
@@ -193,8 +189,6 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
 
         it 'returns items' do
           allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
-
-          result
 
           expect(result['items'].length).to eq 1
           expect(result['items'].first['type']).to eq 'Canvas'


### PR DESCRIPTION
Closes #34 

# Summary

This PR will add a `thumbnail` property to each `Canvas` item and also add one to the base manifest.

- add `ThumbnailBuilder` and spec
- add to and modify existing specs
- add some configuration for the `thumbnail` property
- improve `README`

## Approach

My approach was coming from using a Hyku `4.1.0` with Hyrax `3.4.1` which uses RIIIF `1.7.1` as the image server and Universal Viewer `3.1.4`.  I followed the [manifests](https://digital.lib.utk.edu/assemble/manifest/acwiley/280) from The University of Tennessee, Knoxville as an example.  I am using a scaled down version of the IIIF image itself as the thumbnail instead of a pre-generated image for now.  Also, since UV works fine with displaying thumbnails with a version 2 manifest, the focus was on version 3 to address this issue: https://github.com/UniversalViewer/universalviewer/issues/102.  I did my best to follow the existing pattern.

## Screenshots

<img width="716" alt="image" src="https://user-images.githubusercontent.com/19597776/195928448-ce280a04-383b-4bc4-9588-4a6626be3b4f.png">

<img width="518" alt="image" src="https://user-images.githubusercontent.com/19597776/195867981-eac59065-7b81-453f-a02f-a11e956a36f7.png">