### PR TITLE
remove apply thumbnail to manifest and fix specs

### DIFF
--- a/lib/iiif_manifest/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/manifest_builder/canvas_builder.rb
@@ -1,11 +1,12 @@
 module IIIFManifest
   class ManifestBuilder
     class CanvasBuilder
-      attr_reader :record, :parent, :iiif_canvas_factory, :image_builder
+      attr_reader :record, :parent, :manifest, :iiif_canvas_factory, :image_builder
 
-      def initialize(record, parent, iiif_canvas_factory:, image_builder:)
+      def initialize(record, parent, manifest, iiif_canvas_factory:, image_builder:)
         @record = record
         @parent = parent
+        @manifest = manifest
         @iiif_canvas_factory = iiif_canvas_factory
         @image_builder = image_builder
         apply_record_properties

--- a/lib/iiif_manifest/manifest_builder/canvas_builder_factory.rb
+++ b/lib/iiif_manifest/manifest_builder/canvas_builder_factory.rb
@@ -7,10 +7,10 @@ module IIIFManifest
         @canvas_builder_factory = canvas_builder_factory
       end
 
-      def from(work)
+      def from(work, *manifest)
         composite_builder.new(
           *file_set_presenters(work).map do |presenter|
-            canvas_builder_factory.new(presenter, work)
+            canvas_builder_factory.new(presenter, work, manifest.first)
           end
         )
       end

--- a/lib/iiif_manifest/manifest_builder/structure_builder.rb
+++ b/lib/iiif_manifest/manifest_builder/structure_builder.rb
@@ -78,7 +78,7 @@ module IIIFManifest
 
       def canvas_builders
         @canvas_builders ||= file_set_presenters.map do |file_set_presenter|
-          canvas_builder_factory.new(file_set_presenter, parent)
+          canvas_builder_factory.new(file_set_presenter, parent, nil)
         end
       end
 

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -2,11 +2,12 @@ module IIIFManifest
   module V3
     class ManifestBuilder
       class CanvasBuilder
-        attr_reader :record, :parent, :iiif_canvas_factory, :content_builder,
+        attr_reader :record, :parent, :manifest, :iiif_canvas_factory, :content_builder,
                     :choice_builder, :iiif_annotation_page_factory, :thumbnail_builder_factory
 
         def initialize(record,
                        parent,
+                       manifest,
                        iiif_canvas_factory:,
                        content_builder:,
                        choice_builder:,
@@ -14,6 +15,7 @@ module IIIFManifest
                        thumbnail_builder_factory:)
           @record = record
           @parent = parent
+          @manifest = manifest
           @iiif_canvas_factory = iiif_canvas_factory
           @content_builder = content_builder
           @choice_builder = choice_builder
@@ -58,15 +60,17 @@ module IIIFManifest
           canvas.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
           annotation_page['id'] = "#{path}/annotation_page/#{annotation_page.index}"
           canvas.items = [annotation_page]
-          apply_thumbnail_to(canvas)
+          apply_thumbnail_to(manifest, canvas)
         end
 
-        def apply_thumbnail_to(canvas)
+        def apply_thumbnail_to(manifest, canvas)
           return unless iiif_endpoint
 
           if display_image
+            manifest&.thumbnail ||= Array(thumbnail_builder_factory.new(display_image).build)
             canvas.thumbnail = Array(thumbnail_builder_factory.new(display_image).build)
           elsif display_content.try(:first)
+            manifest&.thumbnail ||= Array(thumbnail_builder_factory.new(display_content.first).build)
             canvas.thumbnail = Array(thumbnail_builder_factory.new(display_content.first).build)
           end
         end

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -63,16 +63,32 @@ module IIIFManifest
           apply_thumbnail_to(manifest, canvas)
         end
 
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
         def apply_thumbnail_to(manifest, canvas)
           return unless iiif_endpoint
 
           if display_image
-            manifest&.thumbnail ||= Array(thumbnail_builder_factory.new(display_image).build)
+            if collection?
+              manifest&.thumbnail = [] if manifest&.thumbnail.nil?
+              manifest.thumbnail << Array(thumbnail_builder_factory.new(display_image).build)
+            else
+              manifest&.thumbnail ||= Array(thumbnail_builder_factory.new(display_image).build)
+            end
             canvas.thumbnail = Array(thumbnail_builder_factory.new(display_image).build)
           elsif display_content.try(:first)
-            manifest&.thumbnail ||= Array(thumbnail_builder_factory.new(display_content.first).build)
+            if collection?
+              manifest&.thumbnail = [] if manifest&.thumbnail.nil?
+              manifest.thumbnail << Array(thumbnail_builder_factory.new(display_content.first).build)
+            else
+              manifest&.thumbnail ||= Array(thumbnail_builder_factory.new(display_content.first).build)
+            end
             canvas.thumbnail = Array(thumbnail_builder_factory.new(display_content.first).build)
           end
+        end
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+
+        def collection?
+          manifest.class.inspect == 'IIIFManifest::V3::ManifestBuilder::IIIFManifest::Collection'
         end
 
         def annotation_page

--- a/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
@@ -72,6 +72,10 @@ module IIIFManifest
           inner_hash['homepage'] = homepage
         end
 
+        def thumbnail
+          inner_hash['thumbnail']
+        end
+
         def thumbnail=(thumbnail)
           inner_hash['thumbnail'] = thumbnail
         end

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -18,7 +18,7 @@ module IIIFManifest
         def apply(manifest)
           setup_manifest_from_record(manifest, record)
           # Build the items array
-          canvas_builder.apply(manifest.items)
+          canvas_builder(manifest).apply(manifest.items)
           manifest
         end
 
@@ -36,8 +36,8 @@ module IIIFManifest
 
         private
 
-        def canvas_builder
-          canvas_builder_factory.from(record)
+        def canvas_builder(manifest)
+          canvas_builder_factory.from(record, manifest)
         end
 
         # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/MethodLength
@@ -56,7 +56,6 @@ module IIIFManifest
           manifest.rendering = populate_rendering if populate_rendering.present?
           homepage = ::IIIFManifest.config.manifest_value_for(record, property: :homepage)
           manifest.homepage = homepage if homepage.present?
-          apply_thumbnail_to(manifest)
         end
         # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/MethodLength
 
@@ -98,30 +97,6 @@ module IIIFManifest
           metadata_field['label'] = ManifestBuilder.language_map(field['label'])
           metadata_field['value'] = ManifestBuilder.language_map(field['value'])
           metadata_field
-        end
-
-        def apply_thumbnail_to(manifest)
-          return unless iiif_endpoint
-
-          if display_image
-            manifest.thumbnail = Array(thumbnail_builder_factory.new(display_image).build)
-          elsif display_content
-            manifest.thumbnail = Array(thumbnail_builder_factory.new(display_content).build)
-          end
-        end
-
-        def display_image
-          return @display_image if defined?(@display_image)
-          @display_image = record.try(:member_presenters)&.first&.display_image
-        end
-
-        def display_content
-          return @display_content if defined?(@display_content)
-          @display_content = record.try(:member_presenters)&.first&.display_content
-        end
-
-        def iiif_endpoint
-          display_image.try(:iiif_endpoint) || Array(display_content).first.try(:iiif_endpoint)
         end
       end
     end

--- a/lib/iiif_manifest/v3/manifest_builder/structure_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/structure_builder.rb
@@ -38,7 +38,7 @@ module IIIFManifest
         def canvas_builders
           @canvas_builders ||= [] unless record.respond_to?(:file_set_presenters)
           @canvas_builders ||= file_set_presenters.map do |file_set_presenter|
-            canvas_builder_factory.new(file_set_presenter, parent)
+            canvas_builder_factory.new(file_set_presenter, parent, nil)
           end
           @canvas_builders
         end
@@ -69,7 +69,7 @@ module IIIFManifest
         end
 
         def canvas_range_item(range_item)
-          canvas_builder = canvas_builder_factory.new(range_item, parent)
+          canvas_builder = canvas_builder_factory.new(range_item, parent, nil)
           { 'type' => 'Canvas', 'id' => canvas_builder.path }
         end
 

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
     allow(content_builder).to receive(:new).and_return(built_content)
     allow(thumbnail_builder).to receive(:build).and_return(iiif_thumbnail)
     allow(thumbnail_builder_factory).to receive(:new).and_return(thumbnail_builder)
-    allow(manifest).to receive(:thumbnail).and_return(iiif_thumbnail)
+    # allow(manifest).to receive(:thumbnail).and_return(iiif_thumbnail)
   end
 
   let(:iiif_body) do
@@ -105,7 +105,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
   end
 
   let(:manifest) do
-    instance_double(IIIFManifest::V3::ManifestBuilder::IIIFManifest)
+    IIIFManifest::V3::ManifestBuilder::IIIFManifest.new
   end
 
   let(:built_content) do
@@ -155,10 +155,17 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
         expect(values).to include "width" => "100px"
         expect(values).to include "height" => "100px"
         expect(values).to include "duration" => nil
-        expect(manifest.thumbnail['type']).to eq 'Image'
-        expect(manifest.thumbnail['width']).to eq 200
-        expect(manifest.thumbnail['height']).to eq 150
-        expect(manifest.thumbnail['duration']).to be_nil
+      end
+
+      it 'sets the manifest thumbnail as well' do
+        builder.canvas
+        expect(manifest.thumbnail).to be_an Array
+        manifest_thumbnail = manifest.thumbnail.first
+        expect(manifest_thumbnail).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::Thumbnail
+        expect(manifest_thumbnail['type']).to eq 'Image'
+        expect(manifest_thumbnail['width']).to eq 200
+        expect(manifest_thumbnail['height']).to eq 150
+        expect(manifest_thumbnail['duration']).to be_nil
       end
     end
 

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
     described_class.new(
       record,
       parent,
+      manifest,
       iiif_canvas_factory: IIIFManifest::V3::ManifestBuilder::IIIFManifest::Canvas,
       content_builder: content_builder,
       choice_builder: IIIFManifest::V3::ManifestBuilder::ChoiceBuilder,
@@ -57,6 +58,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
     allow(content_builder).to receive(:new).and_return(built_content)
     allow(thumbnail_builder).to receive(:build).and_return(iiif_thumbnail)
     allow(thumbnail_builder_factory).to receive(:new).and_return(thumbnail_builder)
+    allow(manifest).to receive(:thumbnail).and_return(iiif_thumbnail)
   end
 
   let(:iiif_body) do
@@ -100,6 +102,10 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
 
   let(:thumbnail_builder_factory) do
     double('Thumbnail Builder')
+  end
+
+  let(:manifest) do
+    instance_double(IIIFManifest::V3::ManifestBuilder::IIIFManifest)
   end
 
   let(:built_content) do
@@ -149,6 +155,10 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
         expect(values).to include "width" => "100px"
         expect(values).to include "height" => "100px"
         expect(values).to include "duration" => nil
+        expect(manifest.thumbnail['type']).to eq 'Image'
+        expect(manifest.thumbnail['width']).to eq 200
+        expect(manifest.thumbnail['height']).to eq 150
+        expect(manifest.thumbnail['duration']).to be_nil
       end
     end
 

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -156,17 +156,6 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
         expect(result['items'].first['items'].first['items'].first['body']['format']).to eq 'image/jpeg'
       end
 
-      it 'has a thumbnail property' do
-        allow(book_presenter).to receive(:member_presenters).and_return([file_presenter])
-
-        thumbnail = result['thumbnail'].first
-        expect(thumbnail['id']).to eq 'test.host/images/image-77/full/!200,200/0/default.jpg'
-        expect(thumbnail['height']).to eq 150
-        expect(thumbnail['width']).to eq 200
-        expect(thumbnail['format']).to eq 'image/jpeg'
-        expect(thumbnail['service'].first).to be_kind_of IIIFManifest::V3::ManifestBuilder::IIIFService
-      end
-
       it 'builds a structure if it can' do
         allow(book_presenter).to receive(:file_set_presenters).and_return([file_presenter])
         allow(book_presenter.ranges[0].ranges[0]).to receive(:file_set_presenters).and_return([file_presenter])


### PR DESCRIPTION
@cjcolvar This is my attempt to remove `apply_thumbnail_to(manifest)`.  It definitely turned out more hairy than I thought.  I couldn't manage to find a way to test it either without investing a lot more time into it.  This changed a lot of files so I'm not fully convinced it worth it.  Let me know what you think, or if there's a better way 😅 