### PR TITLE
Add id value to "Choice" annotations

### DIFF
--- a/lib/iiif_manifest/v3/manifest_builder/choice_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/choice_builder.rb
@@ -12,12 +12,13 @@ module IIIFManifest
         end
 
         def apply(canvas)
+          # Assume first item in canvas is an annotation page
+          annotation['id'] = "#{canvas.items.first['id']}/annotation/#{annotation.index}"
           annotation['target'] = canvas['id']
           canvas['width'] = choice.items.first['width']
           canvas['height'] = choice.items.first['height']
           canvas['duration'] = choice.items.first['duration']
           annotation.body = choice
-          # Assume first item in canvas is an annotation page
           canvas.items.first.items += [annotation]
         end
 

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -520,6 +520,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
       end
 
       let(:file_presenter) { DisplayContentPresenter.new(content: content) }
+      let(:content_annotation_id) { result['items'].first['items'].first['items'].first['id'] }
       let(:content_annotation_body) { result['items'].first['items'].first['items'].first['body'] }
 
       context 'with a DisplayImage' do
@@ -651,6 +652,7 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
         end
 
         it 'returns items' do
+          expect(content_annotation_id).not_to be_empty
           expect(content_annotation_body['type']).to eq 'Choice'
           expect(content_annotation_body['choiceHint']).to eq 'user'
           expect(content_annotation_body.items.size).to eq 3


### PR DESCRIPTION
When adding generation of an ID value to the Annotation field we missed the case for the `Choice` construct. This PR fixes that oversight by adding ID generation to the `choice_builder.rb`