### PR TITLE
Redesign id assignment in annotation_content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.byebug_history

--- a/lib/iiif_manifest/v3/annotation_content.rb
+++ b/lib/iiif_manifest/v3/annotation_content.rb
@@ -1,10 +1,15 @@
 module IIIFManifest
   module V3
     class AnnotationContent
-      attr_reader :url, :type, :motivation, :format, :language, :label, :value, :media_fragment
+      attr_reader :annotation_id, :body_id, :type, :motivation, :format, :language, :label, :value, :media_fragment
 
-      def initialize(url, type:, motivation:, **kwargs)
-        @url = url
+      def initialize(type:, motivation:, **kwargs)
+        # If a user requires a specific ID at the annotation level, this attr overrides
+        # the automatic ID creation.
+        @annotation_id = kwargs[:annotation_id]
+        # Body level ids are only required for annotations delivering content,
+        # such as a transcript/caption file or an annotation containing an image.
+        @body_id = kwargs[:body_id]
         @type = type
         @motivation = motivation
         @format = kwargs[:format]

--- a/lib/iiif_manifest/v3/manifest_builder/annotation_content_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/annotation_content_builder.rb
@@ -13,8 +13,7 @@ module IIIFManifest
         def apply(canvas)
           # Assume first item in canvas annotations is an annotation page
           canvas_id = canvas.annotations.first['id']
-          motivation = annotation_content.motivation if annotation_content.try(:motivation).present?
-          generic_annotation['id'] = "#{canvas_id}/#{motivation}/#{generic_annotation.index}"
+          generic_annotation['id'] = annotation_id(canvas_id)
           generic_annotation['target'] = target(canvas)
           generic_annotation['motivation'] = motivation
           generic_annotation
@@ -32,6 +31,18 @@ module IIIFManifest
 
         def generic_annotation
           @generic_annotation ||= iiif_annotation_factory.new
+        end
+
+        def annotation_id(canvas_id)
+          if annotation_content.try(:annotation_id).blank?
+            "#{canvas_id}/#{motivation}/#{generic_annotation.index}"
+          else
+            annotation_content.annotation_id
+          end
+        end
+
+        def motivation
+          annotation_content.motivation if annotation_content.try(:motivation).present?
         end
 
         def target(canvas)

--- a/lib/iiif_manifest/v3/manifest_builder/annotation_content_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/annotation_content_builder.rb
@@ -35,7 +35,7 @@ module IIIFManifest
 
         def annotation_id(canvas_id)
           if annotation_content.try(:annotation_id).blank?
-            "#{canvas_id}/#{motivation}/#{generic_annotation.index}"
+            "#{canvas_id}/#{motivation.presence || 'annotation'}/#{generic_annotation.index}"
           else
             annotation_content.annotation_id
           end

--- a/lib/iiif_manifest/v3/manifest_builder/body_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/body_builder.rb
@@ -19,7 +19,7 @@ module IIIFManifest
         private
 
         def build_body
-          body['id'] = content.url
+          body['id'] = body_id
           body['type'] = body_type
           body_display_dimensions
           body['format'] = content.format if content.try(:format).present?
@@ -30,6 +30,15 @@ module IIIFManifest
 
         def body
           @body ||= iiif_body_factory.new
+        end
+
+        def body_id
+          return if content.try(:body_id).blank? && content.try(:url).blank?
+          if content.try(:body_id).present?
+            content.body_id
+          else
+            content.url
+          end
         end
 
         def body_type

--- a/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/body_builder_spec.rb
@@ -178,6 +178,58 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::BodyBuilder do
           expect(annotation.body['service']).to include auth_service
         end
       end
+
+      describe 'annotation_content' do
+        let(:builder) do
+          described_class.new(
+            annotation_content,
+            iiif_body_factory: IIIFManifest::V3::ManifestBuilder::IIIFManifest::Body,
+            image_service_builder_factory: image_service_builder_factory
+          )
+        end
+
+        context 'with body_id' do
+          let(:url) { "http://transcript.vtt" }
+          let(:annotation_content) do
+            IIIFManifest::V3::AnnotationContent.new(body_id: url,
+                                                    type: 'text',
+                                                    motivation: 'supplementing',
+                                                    format: 'text/vtt',
+                                                    label: 'English',
+                                                    language: 'eng')
+          end
+
+          it 'sets a body on the annotation' do
+            subject
+            expect(annotation.body).to be_kind_of IIIFManifest::V3::ManifestBuilder::IIIFManifest::Body
+            expect(annotation.body['id']).to eq url
+            expect(annotation.body['type']).to eq 'text'
+            expect(annotation.body['label']).to eq('none' => ['English'])
+            expect(annotation.body['format']).to eq 'text/vtt'
+            expect(annotation.body['language']).to eq 'eng'
+          end
+        end
+        context 'with annotation_id' do
+          let(:url) { "http://highlight.mark" }
+          let(:annotation_content) do
+            IIIFManifest::V3::AnnotationContent.new(annotation_id: url,
+                                                    type: 'TextualBody',
+                                                    motivation: 'highlighting',
+                                                    format: 'text/html',
+                                                    value: 'marker',
+                                                    media_fragment: 't=15')
+          end
+
+          it 'sets a body on the annotation' do
+            subject
+            expect(annotation.body).to be_kind_of IIIFManifest::V3::ManifestBuilder::IIIFManifest::Body
+            expect(annotation.body['id']).to be_nil
+            expect(annotation.body['type']).to eq 'TextualBody'
+            expect(annotation.body['value']).to eq 'marker'
+            expect(annotation.body['format']).to eq 'text/html'
+          end
+        end
+      end
     end
   end
 end

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
                                                             format: 'image/jpeg')
   end
   let(:annotation_content) do
-    IIIFManifest::V3::AnnotationContent.new(caption_url,
+    IIIFManifest::V3::AnnotationContent.new(body_id: caption_url,
                                             type: 'text',
                                             motivation: 'supplementing',
                                             format: 'text/vtt',
@@ -398,19 +398,19 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
         )
       end
       let(:annotation_content) do
-        [IIIFManifest::V3::AnnotationContent.new("http://highlight.mark",
+        [IIIFManifest::V3::AnnotationContent.new(annotation_id: "http://highlight.mark",
                                                  type: 'TextualBody',
                                                  motivation: 'highlighting',
                                                  format: 'text/html',
                                                  value: 'marker',
                                                  media_fragment: 't=15'),
-         IIIFManifest::V3::AnnotationContent.new("http://transcript.vtt",
+         IIIFManifest::V3::AnnotationContent.new(body_id: "http://transcript.vtt",
                                                  type: 'text',
                                                  motivation: 'supplementing',
                                                  format: 'text/vtt',
                                                  label: 'English',
                                                  language: 'eng'),
-         IIIFManifest::V3::AnnotationContent.new("http://caption.vtt",
+         IIIFManifest::V3::AnnotationContent.new(body_id: "http://caption.vtt",
                                                  type: 'text',
                                                  motivation: 'supplementing',
                                                  format: 'text/vtt',
@@ -438,6 +438,7 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
         expect(annotations.length).to eq 1
         annotation_page = annotations.first
         expect(annotation_page.items.length).to eq 3
+        expect(annotation_page.items[0].inner_hash['id']).to eq "http://highlight.mark"
         expect(annotation_page.items[0].inner_hash['target']).to include '#t=15'
         expect(annotation_page.items[1].body.inner_hash['language']).to eq 'eng'
         expect(annotation_page.items[2].body.inner_hash['language']).to eq 'eng'

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -446,6 +446,40 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
       end
     end
 
+    context "when annotation_content has no annotation_id and no motivation" do
+      let(:annotation_content) do
+        IIIFManifest::V3::AnnotationContent.new(motivation: nil,
+                                                type: 'TextualBody',
+                                                format: 'text/html',
+                                                value: 'marker',
+                                                media_fragment: 't=15')
+      end
+
+      it 'generates the canvas' do
+        canvas = builder.canvas
+        expect(canvas).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::Canvas
+        values = canvas.inner_hash
+
+        expect(values).to include "type" => "Canvas"
+        expect(values).to include "id" => "http://test.host/books/book-77/manifest/canvas/test-22"
+
+        expect(values).to include 'items'
+        items = values['items']
+        expect(items.length).to eq 1
+        page = items.first
+        expect(page).to be_a IIIFManifest::V3::ManifestBuilder::IIIFManifest::AnnotationPage
+        expect(page.items).not_to be_empty
+
+        expect(values).to include 'annotations'
+        annotations = values['annotations']
+        expect(annotations.length).to eq 1
+        annotation_page = annotations.first
+        expect(annotation_page.items[0].inner_hash['id']).to match(/.+\/annotation\/.+/)
+        expect(annotation_page.items[0].inner_hash['target']).to include '#t=15'
+        expect(annotation_page.items).to all(be_a(IIIFManifest::V3::ManifestBuilder::IIIFManifest::Annotation))
+      end
+    end
+
     context 'when placeholder_content is specificed for a record' do
       it 'generates placeholderCanvas' do
         canvas = builder.canvas


### PR DESCRIPTION
Presentation 3 Annotation bodies do not require an id field unless they are linking to content that must be downloaded, such as a transcript file. Additionally, there may be use cases where a user needs or wants to provide their own ID to the annotations themselves. Providing id attrs for annotation_content and removing the requirement for a URL allows us to provide greater granularity to accommodate these use cases.