### PR TITLE
Allow arbitrary service resources at the manifest level

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Additionally it **_should_** implement `#manifest_metadata` to provide an array 
 
 Additionally it **_may_** implement `#search_service` to contain the url for a IIIF search api compliant search endpoint and `#autocomplete_service` to contain the url for a IIIF search api compliant autocomplete endpoint. Please note, the autocomplete service is embedded within the search service description so if an autocomplete_service is supplied without a search_service it will be ignored. The IIIF `profile` added to the service descriptions is version 0 as this is the version supported by the current version of Universal Viewer. Only include a search_service within the manifest if your application has implemented a IIIF search service at the endpoint specified in the manifest.
 
+Additionally it **_may_** implement `#service` to contain an array of hashes for services other than `search_service` or `autocomplete_service`.  Each must contain "@id" (V2) or "id" (V3) and "@context" (V2) or "type" (V3) and may contain any other arbitrary properties.
+
 Additionally it **_may_** implement `#sequence_rendering` to contain an array of hashes for file downloads to be offered at sequences level. Each hash must contain "@id", "format" (mime type) and "label" (eg. `{ "@id" => "download url", "format" => "application/pdf", "label" => "user friendly label" }`).
 
 Finally, it **_may_** implement `ranges`, which returns an array of objects which represent a table of contents or similar structure, each of which responds to `label`, `ranges`, and `file_set_presenters`.
@@ -74,6 +76,16 @@ For example:
 
     def autocomplete_service
       "http://test.host/books/#{@id}/autocomplete"
+    end
+
+    def service
+      [
+        {
+          "@context" => "http://iiif.io/api/annext/services/example/context.json",
+          "@id" => "https://example.org/service",
+          "profile" => "https://example.org/docs/service"
+        }
+      ]
     end
 
     def sequence_rendering

--- a/lib/iiif_manifest/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/manifest_builder/record_property_builder.rb
@@ -48,15 +48,24 @@ module IIIFManifest
         @iiif_autocomplete_service ||= iiif_autocomplete_service_factory.new
       end
 
+      def custom_services
+        record.respond_to?(:service) ? record.send(:service) : []
+      end
+
         # Build services. Currently supported:
         #   search_service, with (optional) embedded autocomplete service
         #
         # @return [Array] array of services
       def services
-        iiif_search_service.search_service = search_service
-        iiif_autocomplete_service.autocomplete_service = autocomplete_service
-        iiif_search_service.service = iiif_autocomplete_service if autocomplete_service.present?
-        [iiif_search_service]
+        services = []
+        if search_service.present?
+          iiif_search_service.search_service = search_service
+          iiif_autocomplete_service.autocomplete_service = autocomplete_service
+          iiif_search_service.service = iiif_autocomplete_service if autocomplete_service.present?
+          services << iiif_search_service
+        end
+        services += Array(custom_services)
+        services
       end
 
         # Validate manifest_metadata against the IIIF spec format for metadata

--- a/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/record_property_builder.rb
@@ -53,7 +53,7 @@ module IIIFManifest
           manifest.behavior = viewing_hint if viewing_hint.present?
           manifest.metadata = metadata_from_record(record) if metadata_from_record(record).present?
           manifest.viewing_direction = viewing_direction if viewing_direction.present?
-          manifest.service = services if search_service.present?
+          manifest.service = services if services.present?
           manifest.rendering = populate_rendering if populate_rendering.present?
           homepage = ::IIIFManifest.config.manifest_value_for(record, property: :homepage)
           manifest.homepage = homepage if homepage.present?

--- a/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_factory_spec.rb
@@ -392,6 +392,34 @@ RSpec.describe IIIFManifest::V3::ManifestFactory do
       end
     end
 
+    context 'with custom services' do
+      let(:services) { [service] }
+      let(:service) do
+        {
+          id: "https://example.org/service",
+          type: "ExampleExtensionService",
+          profile: "https://example.org/docs/service",
+          customProperty: "Custom Configuration"
+        }
+      end
+
+      it 'has a service element' do
+        allow(book_presenter).to receive(:service).and_return(services)
+        expect(result['service']).to include service
+      end
+
+      context 'when search service is also present' do
+        let(:search_service) { 'http://test.host/books/book-77/search' }
+
+        it 'has both services' do
+          allow(book_presenter).to receive(:search_service).and_return(search_service)
+          allow(book_presenter).to receive(:service).and_return(services)
+          expect(result['service']).to include service
+          expect(result['service']).to include IIIFManifest::V3::ManifestBuilder::IIIFManifest::SearchService
+        end
+      end
+    end
+
     context 'when there are child works' do
       let(:child_work_presenter) { presenter_class.new('test2', label: 'Inner book') }
 


### PR DESCRIPTION
Avalon needs to add a service property to our manifests at the root manifest level to surface an annotation service for our IIIF player Ramp.  There isn't a standardized spec for an annotation service so we need to be able to add custom service resources with custom properties.  This PR allows a presenter to define a `#service` method which returns an array of hashes with service definitions which will be added to the manifest wholesale (alongside the `service_service` and `autocomplete_service` if defined).