### PR TITLE
Update guard clause to avoid NoMethodError

### DIFF
--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -57,7 +57,9 @@ module IIIFManifest
         # @return [Array<Object>] if the record has a display content
         # @return [NilClass] if there is no display content
         def display_content
-          Array.wrap(record.display_content) if record.respond_to?(:display_content) && record.display_content.present?
+          return unless record.respond_to?(:display_content) && record.display_content.present?
+
+          Array.wrap(record.display_content)
         end
 
         # @return [Array<Object>] if the record has generic annotation content
@@ -136,7 +138,7 @@ module IIIFManifest
         def populate(property)
           property = :sequence_rendering if property == :rendering
 
-          return unless record.respond_to?(property)
+          return unless record.respond_to?(property) && record.send(property).present?
           record.send(property).collect do |prop|
             output = prop.to_h.except('@id', 'label')
             output['id'] = prop['@id']


### PR DESCRIPTION
The #populate method in the V3 canvas builder performs a `collect` on the input. This caused a NoMethodError to be generated when the input was nil. Changing the guard clause to check for `respond_to?` and `present?` should fix this case.

This commit also changes the `if` check in #display_content to a guard clause to match the style in #annotation_content.