### PR TITLE
Avoid creating canvas builders just to compute id

### DIFF
--- a/lib/iiif_manifest/v3/manifest_builder/structure_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/structure_builder.rb
@@ -32,11 +32,7 @@ module IIIFManifest
           range['id'] = path
           range['label'] = ManifestBuilder.language_map(record.label) if record.try(:label).present?
           range['behavior'] = 'top' if top?
-          if record.respond_to?(:file_set_presenters)
-            range['items'] = record.file_set_presenters.collect { |fs| { 'type' => 'Canvas', 'id' => build_canvas_id(fs) } }
-          else
-            range['items'] = []
-          end
+          range['items'] = file_set_presenters.collect { |fs| { 'type' => 'Canvas', 'id' => build_canvas_id(fs) } }
         end
 
         def canvas_builders
@@ -86,6 +82,10 @@ module IIIFManifest
         end
 
         private
+
+        def file_set_presenters
+          record.respond_to?(:file_set_presenters) ? record.file_set_presenters : []
+        end
 
         def build_canvas_id(canvas_item)
           path = "#{parent.manifest_url}/canvas/#{canvas_item.id}"

--- a/lib/iiif_manifest/v3/manifest_builder/structure_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/structure_builder.rb
@@ -32,7 +32,7 @@ module IIIFManifest
           range['id'] = path
           range['label'] = ManifestBuilder.language_map(record.label) if record.try(:label).present?
           range['behavior'] = 'top' if top?
-          range['items'] = file_set_presenters.collect { |presenter| { 'type' => 'Canvas', 'id' => build_canvas_id(presenter) } }
+          range['items'] = file_set_presenters.collect { |fs| { 'type' => 'Canvas', 'id' => build_canvas_id(fs) } }
         end
 
         def canvas_builders
@@ -85,7 +85,9 @@ module IIIFManifest
         
         def build_canvas_id(canvas_item)
           path = "#{parent.manifest_url}/canvas/#{canvas_item.id}"
-          path << "##{canvas_item.media_fragment}" if canvas_item.respond_to?(:media_fragment) && canvas_item.media_fragment.present?
+          if canvas_item.respond_to?(:media_fragment) && canvas_item.media_fragment.present?
+            path << "##{canvas_item.media_fragment}"
+          end
           path
         end
       end

--- a/lib/iiif_manifest/v3/manifest_builder/structure_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/structure_builder.rb
@@ -82,7 +82,7 @@ module IIIFManifest
         end
 
         private
-        
+
         def build_canvas_id(canvas_item)
           path = "#{parent.manifest_url}/canvas/#{canvas_item.id}"
           if canvas_item.respond_to?(:media_fragment) && canvas_item.media_fragment.present?

--- a/lib/iiif_manifest/v3/manifest_builder/structure_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/structure_builder.rb
@@ -32,7 +32,11 @@ module IIIFManifest
           range['id'] = path
           range['label'] = ManifestBuilder.language_map(record.label) if record.try(:label).present?
           range['behavior'] = 'top' if top?
-          range['items'] = file_set_presenters.collect { |fs| { 'type' => 'Canvas', 'id' => build_canvas_id(fs) } }
+          if record.respond_to?(:file_set_presenters)
+            range['items'] = record.file_set_presenters.collect { |fs| { 'type' => 'Canvas', 'id' => build_canvas_id(fs) } }
+          else
+            range['items'] = []
+          end
         end
 
         def canvas_builders

--- a/lib/iiif_manifest/v3/manifest_builder/structure_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/structure_builder.rb
@@ -32,7 +32,7 @@ module IIIFManifest
           range['id'] = path
           range['label'] = ManifestBuilder.language_map(record.label) if record.try(:label).present?
           range['behavior'] = 'top' if top?
-          range['items'] = canvas_builders.collect { |cb| { 'type' => 'Canvas', 'id' => cb.path } }
+          range['items'] = file_set_presenters.collect { |presenter| { 'type' => 'Canvas', 'id' => build_canvas_id(presenter) } }
         end
 
         def canvas_builders
@@ -69,8 +69,7 @@ module IIIFManifest
         end
 
         def canvas_range_item(range_item)
-          canvas_builder = canvas_builder_factory.new(range_item, parent)
-          { 'type' => 'Canvas', 'id' => canvas_builder.path }
+          { 'type' => 'Canvas', 'id' => build_canvas_id(range_item) }
         end
 
         def range_range_item(range_item)
@@ -80,6 +79,14 @@ module IIIFManifest
             canvas_builder_factory: canvas_builder_factory,
             iiif_range_factory: iiif_range_factory
           )
+        end
+
+        private
+        
+        def build_canvas_id(canvas_item)
+          path = "#{parent.manifest_url}/canvas/#{canvas_item.id}"
+          path << "##{canvas_item.media_fragment}" if canvas_item.respond_to?(:media_fragment) && canvas_item.media_fragment.present?
+          path
         end
       end
     end


### PR DESCRIPTION
Copy `#path` method from CanvasBuilder to avoid doing a lot of extra work and potential fetching of data.

`CanvasBuilder#initialize` does most of the work of setting up the canvas instead of in `#apply` so it is fairly expensive especially when doing this for hundreds of canvases.