### PR TITLE
Memoize to avoid duplicate fetching/building of content

### DIFF
--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -51,27 +51,29 @@ module IIIFManifest
         private
 
         def display_image
-          record.display_image if record.respond_to?(:display_image)
+          @display_image ||= record.display_image if record.respond_to?(:display_image)
         end
 
         # @return [Array<Object>] if the record has a display content
         # @return [NilClass] if there is no display content
         def display_content
+          return @display_content if @display_content.present?
           return unless record.respond_to?(:display_content) && record.display_content.present?
 
-          Array.wrap(record.display_content)
+          @display_content ||= Array.wrap(record.display_content)
         end
 
         # @return [Array<Object>] if the record has generic annotation content
         # @return [NilClass] if there is no annotation content
         def annotation_content
+          return @annotation_content if @annotation_content.present?
           return unless record.respond_to?(:annotation_content) && record.annotation_content.present?
 
-          Array.wrap(record.annotation_content)
+          @annotation_content ||= Array.wrap(record.annotation_content)
         end
 
         def placeholder_content
-          record.placeholder_content if record.respond_to?(:placeholder_content)
+          @placeholder_content ||= record.placeholder_content if record.respond_to?(:placeholder_content)
         end
 
         # rubocop:disable Metrics/AbcSize

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -57,8 +57,8 @@ module IIIFManifest
         # @return [Array<Object>] if the record has a display content
         # @return [NilClass] if there is no display content
         def display_content
-          return @display_content if @display_content.present?
-          return unless record.respond_to?(:display_content) && record.display_content.present?
+          return @display_content unless @display_content.nil?
+          return unless record.respond_to?(:display_content) && !record.display_content.nil?
 
           @display_content ||= Array.wrap(record.display_content)
         end
@@ -66,8 +66,8 @@ module IIIFManifest
         # @return [Array<Object>] if the record has generic annotation content
         # @return [NilClass] if there is no annotation content
         def annotation_content
-          return @annotation_content if @annotation_content.present?
-          return unless record.respond_to?(:annotation_content) && record.annotation_content.present?
+          return @annotation_content unless @annotation_content.nil?
+          return unless record.respond_to?(:annotation_content) && !record.annotation_content.nil?
 
           @annotation_content ||= Array.wrap(record.annotation_content)
         end

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -57,19 +57,15 @@ module IIIFManifest
         # @return [Array<Object>] if the record has a display content
         # @return [NilClass] if there is no display content
         def display_content
-          return @display_content unless @display_content.nil?
-          return unless record.respond_to?(:display_content) && !record.display_content.nil?
-
-          @display_content ||= Array.wrap(record.display_content)
+          @display_content ||= Array.wrap(record.display_content) if record.respond_to?(:display_content)
+          @display_content.presence
         end
 
         # @return [Array<Object>] if the record has generic annotation content
         # @return [NilClass] if there is no annotation content
         def annotation_content
-          return @annotation_content unless @annotation_content.nil?
-          return unless record.respond_to?(:annotation_content) && !record.annotation_content.nil?
-
-          @annotation_content ||= Array.wrap(record.annotation_content)
+          @annotation_content ||= Array.wrap(record.annotation_content) if record.respond_to?(:annotation_content)
+          @annotation_content.presence
         end
 
         def placeholder_content


### PR DESCRIPTION
Memoizing avoid duplicate fetching of these values which can be expensive especially with a large number of canvases.  In particular these are called multiple times in `#initialize` in `apply_record_properties` and then again in  `attach_*` and their guard clauses.