### PR TITLE
Allow setting summary on a canvas

### DIFF
--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -75,15 +75,11 @@ module IIIFManifest
         # rubocop:disable Metrics/AbcSize
         def apply_record_properties
           canvas['id'] = path
-          canvas.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
           annotation_page['id'] = "#{path}/annotation_page/#{annotation_page.index}"
           canvas.items = [annotation_page]
+          apply_canvas_attributes(canvas)
           apply_annotation_content_to(canvas)
           apply_thumbnail_to(canvas)
-          canvas.rendering = populate(:rendering) if populate(:rendering).present?
-          canvas.see_also = populate(:see_also) if populate(:see_also).present?
-          canvas.part_of = populate(:part_of) if populate(:part_of).present?
-          canvas.metadata = metadata_from_record(record) if metadata_from_record(record).present?
         end
         # rubocop:enable Metrics/AbcSize
 
@@ -101,6 +97,18 @@ module IIIFManifest
             canvas.thumbnail = Array(thumbnail_builder_factory.new(display_content.first).build)
           end
         end
+
+        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        def apply_canvas_attributes(canvas)
+          canvas.label = ManifestBuilder.language_map(record.to_s) if record.to_s.present?
+          canvas.rendering = populate(:rendering) if populate(:rendering).present?
+          canvas.see_also = populate(:see_also) if populate(:see_also).present?
+          canvas.part_of = populate(:part_of) if populate(:part_of).present?
+          canvas.metadata = metadata_from_record(record) if metadata_from_record(record).present?
+          canvas.summary = ManifestBuilder.language_map(record.description) if record.respond_to?(:description) &&
+                                                                               record.description.present?
+        end
+        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def annotation_page
           @annotation_page ||= iiif_annotation_page_factory.new

--- a/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
@@ -169,6 +169,15 @@ module IIIFManifest
           def metadata=(metadata)
             inner_hash['metadata'] = metadata
           end
+
+          def summary
+            inner_hash['summary']
+          end
+
+          def summary=(summary)
+            return unless summary.present?
+            inner_hash['summary'] = summary
+          end
         end
 
         class Range < IIIFService

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -584,6 +584,27 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
         end
       end
     end
+
+    context 'when the description is specified for a record' do
+      before do
+        class MyWork
+          def id
+            'test-22'
+          end
+
+          def description
+            'Ipsum Lorem'
+          end
+        end
+      end
+
+      it 'sets summary for a canvas' do
+        canvas = builder.canvas
+        values = canvas.inner_hash
+
+        expect(values['summary']).to eq('none' => ['Ipsum Lorem'])
+      end
+    end
   end
 
   describe '#new' do


### PR DESCRIPTION
This PR allows adding a `summary` attribute to canvas elements by defining a `description` method on the canvas presenter.  This follows the pattern already implemented for setting `summary` at the manifest level.