### PR TITLE
Allow arbitrary service resources at the Canvas level

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ In Presentation 3.0, additionally it **_may_** implement;
 - `#part_of` to contain an array of hashes for parent resources to be offered at each leaf node. Items must contain "id" and "type" properties. Items should contain "label".
 - `#homepage` to contain an array of hashes for homepage resources to be offered at each leaf node. Items must contain "id", "type", and "label" properties. Items should contain a "format" property and may contain a "language" property.
 - `#placeholder_content` to contain an instance of `IIIFManifest::V3::DisplayContent` for [`placeholderCanvas`](https://iiif.io/api/presentation/3.0/#placeholdercanvas) at each leaf node
+- `#service` to contain an array of hashes for services. Each must contain "id" and "type" and may contain any other arbitrary properties.
 
 ```ruby
   class Page
@@ -146,7 +147,7 @@ In Presentation 3.0, additionally it **_may_** implement;
                                      )
     end
 
-    # --------------------------------------- Presentation 3.0 (Alpha) ---------------------------------------
+    # --------------------------------------- Presentation 3.0 ---------------------------------------
     def sequence_rendering
       [{"@id" => "http://test.host/display_image/id/download", "format" => "application/pdf", "label" => "Download"}]
     end
@@ -170,7 +171,17 @@ In Presentation 3.0, additionally it **_may_** implement;
                                            type: "Image",
                                            format: "image/jpeg")
     end
-    # --------------------------------------- Presentation 3.0 (Alpha) ---------------------------------------
+
+    def service
+      [
+        {
+          "@context" => "http://iiif.io/api/annext/services/example/context.json",
+          "@id" => "https://example.org/service",
+          "profile" => "https://example.org/docs/service"
+        }
+      ]
+    end
+    # --------------------------------------- Presentation 3.0 ---------------------------------------
 
     private
 

--- a/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/canvas_builder.rb
@@ -115,6 +115,7 @@ module IIIFManifest
           canvas.summary = ManifestBuilder.language_map(record.description) if record.respond_to?(:description) &&
                                                                                record.description.present?
           canvas.homepage = populate(:homepage) if populate(:homepage).present?
+          canvas.service = populate(:service) if populate(:service).present?
         end
         # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 

--- a/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
+++ b/lib/iiif_manifest/v3/manifest_builder/iiif_service.rb
@@ -182,6 +182,14 @@ module IIIFManifest
           def homepage=(homepage)
             inner_hash['homepage'] = homepage
           end
+
+          def service
+            inner_hash['service'] || []
+          end
+
+          def service=(service)
+            inner_hash['service'] = service
+          end
         end
 
         class Range < IIIFService

--- a/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
+++ b/spec/lib/iiif_manifest/v3/manifest_builder/canvas_builder_spec.rb
@@ -672,6 +672,30 @@ RSpec.describe IIIFManifest::V3::ManifestBuilder::CanvasBuilder do
         expect(values.key?('homepage')).to be true
       end
     end
+
+    context 'when a service is specified for a record' do
+      before do
+        class MyWork
+          def id
+            'test-22'
+          end
+
+          def service
+            [{
+              id: 'http://example.com/test-22/service',
+              type: 'service1'
+            }]
+          end
+        end
+      end
+
+      it 'sets service for a canvas' do
+        canvas = builder.canvas
+        values = canvas.inner_hash
+
+        expect(values.key?('service')).to be true
+      end
+    end
   end
 
   describe '#new' do


### PR DESCRIPTION
Avalon is looking at implementing IIIF content search 2.0 API to facilitate searching within A/V transcripts. Our expected implementation will have a search service within each leaf node (canvas) as mentioned in avalonmediasystem/avalon#5795. To that end, we need to add an arbitrary service declaration at the canvas level. 

Future improvement could be to expand the `SearchService` and `AutocompleteService` classes to handle both Content Search 1.0 and 2.0, and provide those at the canvas level to match the behavior at the manifest level. For the purposes of this initial work, however, it should be sufficient to just have an arbitrary service handler.