### PR TITLE
Remove Ruby 2.5 and 2.6 from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,12 +49,6 @@ workflows:
       - test:
           name: "ruby2-7"
           ruby_version: "2.7.7"
-      - test:
-          name: "ruby2-6"
-          ruby_version: "2.6.10"
-      - test:
-          name: "ruby2-5"
-          ruby_version: "2.5.9"
 
   nightly:
     triggers:
@@ -80,9 +74,3 @@ workflows:
       - test:
           name: "ruby2-7"
           ruby_version: "2.7.7"
-      - test:
-          name: "ruby2-6"
-          ruby_version: "2.6.10"
-      - test:
-          name: "ruby2-5"
-          ruby_version: "2.5.9"


### PR DESCRIPTION
Closes #115 